### PR TITLE
[RELEASE-1.6] Use v1beta1 for Knative operator crd in tests

### DIFF
--- a/test/e2e/broker_defaults_webhook_test.go
+++ b/test/e2e/broker_defaults_webhook_test.go
@@ -100,7 +100,7 @@ func TestBrokerNamespaceDefaulting(t *testing.T) {
 		*/
 
 		knativeEventing, err := c.Dynamic.
-			Resource(schema.GroupVersionResource{Group: "operator.knative.dev", Version: "v1alpha1", Resource: "knativeeventings"}).
+			Resource(schema.GroupVersionResource{Group: "operator.knative.dev", Version: "v1beta1", Resource: "knativeeventings"}).
 			Namespace(system.Namespace()).Get(ctx, "knative-eventing", metav1.GetOptions{})
 		assert.Nil(t, err)
 
@@ -108,7 +108,7 @@ func TestBrokerNamespaceDefaulting(t *testing.T) {
 		assert.Nil(t, err)
 
 		_, err = c.Dynamic.
-			Resource(schema.GroupVersionResource{Group: "operator.knative.dev", Version: "v1alpha1", Resource: "knativeeventings"}).
+			Resource(schema.GroupVersionResource{Group: "operator.knative.dev", Version: "v1beta1", Resource: "knativeeventings"}).
 			Namespace(system.Namespace()).Update(ctx, knativeEventing, metav1.UpdateOptions{})
 		if err != nil {
 			return err


### PR DESCRIPTION
- See failure https://github.com/openshift-knative/serverless-operator/pull/1818#issuecomment-1321879979
