### PR TITLE
[release-v1.5] SRVKE-1353 Multiarch test images

### DIFF
--- a/.github/workflows/multiarch-build.yaml
+++ b/.github/workflows/multiarch-build.yaml
@@ -1,0 +1,10 @@
+name: Multiarch builds
+
+on:
+  push:
+    branches: [ 'release-v*' ]
+
+jobs:
+  multiarch-build:
+    uses: openshift-knative/hack/.github/workflows/multiarch-build.yaml@main
+    secrets: inherit

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,2 +1,2 @@
 # Use :nonroot base image for all containers
-defaultBaseImage: gcr.io/distroless/static:nonroot
+defaultBaseImage: registry.access.redhat.com/ubi8/ubi-minimal:latest


### PR DESCRIPTION
https://issues.redhat.com/browse/SRVKE-1353

* Include github action for building multiarch test images, similar to what was done for eventing-kafka-broker: [link](https://github.com/openshift-knative/eventing-kafka-broker/blob/main/.github/workflows/multiarch-build.yaml). This github action references the [shared one in openshift-knative/hack repo](https://github.com/openshift-knative/hack/blob/main/.github/workflows/multiarch-build.yaml)
* Allows specifying TEST_IMAGE_TAG and KO_FLAGS for the ko build. These params will be passed by the shared github action

The images will be built upon any commit on the release branch. And will be published to https://quay.io/repository/openshift-knative/eventing/<IMAGE_NAME>