### PR TITLE
[main] SRVKE-1353 Multiarch test images

### DIFF
--- a/.github/workflows/multiarch-build.yaml
+++ b/.github/workflows/multiarch-build.yaml
@@ -1,0 +1,10 @@
+name: Multiarch builds
+
+on:
+  push:
+    branches: [ 'release-v*' ]
+
+jobs:
+  multiarch-build:
+    uses: openshift-knative/hack/.github/workflows/multiarch-build.yaml@main
+    secrets: inherit

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,10 @@ CGO_ENABLED=0
 GOOS=linux
 CORE_IMAGES=$(shell find ./cmd -name main.go ! -path "./cmd/broker/*" ! -path "./cmd/mtbroker/*" | sed 's|/main.go||') ./vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate ./vendor/knative.dev/pkg/leaderelection/chaosduck
 TEST_IMAGES=$(shell find ./test/test_images -mindepth 1 -maxdepth 1 -type d) ./vendor/knative.dev/reconciler-test/cmd/eventshub
-TEST_IMAGE_TAG=latest
-KO_DOCKER_REPO=${DOCKER_REPO_OVERRIDE}
-KO_FLAGS=
 BRANCH=
 TEST=
 IMAGE=
+TEST_IMAGE_TAG ?= latest
 
 # Guess location of openshift/release repo. NOTE: override this if it is not correct.
 OPENSHIFT=${CURDIR}/../../github.com/openshift/release
@@ -41,15 +39,17 @@ test-reconciler:
 	sh openshift/e2e-rekt-tests.sh
 .PHONY: test-reconciler
 
-# Requires ko 0.2.0 or newer.
+# Target used by github actions.
 test-images:
 	for img in $(TEST_IMAGES); do \
-		KO_DOCKER_REPO=$(DOCKER_REPO_OVERRIDE) ko build --tags=$(TEST_IMAGE_TAG) $(KO_FLAGS) -B $$img ; \
+		KO_DOCKER_REPO=$(DOCKER_REPO_OVERRIDE) ko build --tags=$(TEST_IMAGE_TAG) $(KO_FLAGS) -B $$img || \
+		KO_DOCKER_REPO=$(DOCKER_REPO_OVERRIDE) ko resolve --tags=$(TEST_IMAGE_TAG) $(KO_FLAGS) -RBf $$img || exit $?; \
 	done
 .PHONY: test-images
 
 test-image-single:
-	KO_DOCKER_REPO=$(DOCKER_REPO_OVERRIDE) ko build --tags=$(TEST_IMAGE_TAG) $(KO_FLAGS) -B test/test_images/$(IMAGE)
+	KO_DOCKER_REPO=$(DOCKER_REPO_OVERRIDE) ko build --tags=$(TEST_IMAGE_TAG) $(KO_FLAGS) -B test/test_images/$(IMAGE) || \
+	KO_DOCKER_REPO=$(DOCKER_REPO_OVERRIDE) ko resolve --tags=$(TEST_IMAGE_TAG) $(KO_FLAGS) -RBf test/test_images/$(IMAGE)
 .PHONY: test-image-single
 
 # Run make DOCKER_REPO_OVERRIDE=<your_repo> test-e2e-local if test images are available

--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -11,12 +11,16 @@ target=$2
 git fetch upstream --tags
 git checkout -b "$target" "$release"
 
+# Remove GH Action hooks from upstream
+rm -rf .github/workflows
+git commit -sm ":fire: remove unneeded workflows" .github/
+
 # Copy the openshift extra files from the OPENSHIFT/main branch.
 git fetch openshift main
-git checkout openshift/main -- openshift OWNERS_ALIASES OWNERS Makefile
+git checkout openshift/main -- .github/workflows openshift OWNERS_ALIASES OWNERS Makefile
 make generate-dockerfiles
 make RELEASE=$release generate-release
-git add openshift OWNERS_ALIASES OWNERS Makefile
+git add .github/workflows openshift OWNERS_ALIASES OWNERS Makefile
 git commit -m "Add openshift specific files."
 
 # Apply patches .


### PR DESCRIPTION
https://issues.redhat.com/browse/SRVKE-1353

Similar to https://github.com/openshift-knative/eventing/pull/10

This is a variant for "main" branch which automatically removes upstream github actions and adds midstream ones when creating a release branch.