### PR TITLE
[release-v1.7] Add new file permanently to config folder

### DIFF
--- a/config/openshift-serverless-view-eventing-configmaps.yaml
+++ b/config/openshift-serverless-view-eventing-configmaps.yaml
@@ -1,0 +1,41 @@
+# Copyright 2022 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: knative-eventing
+  name: openshift-serverless-view-eventing-configmaps
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openshift-serverless-view-eventing-configmaps
+  namespace: knative-eventing
+subjects:
+  - kind: Group
+    name: system:authenticated
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openshift-serverless-view-eventing-configmaps


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

The `release-v1.7` branch was created _BEFORE_ we corrected the patch for the new file in `config/`, done in:
https://github.com/openshift/knative-eventing/pull/1931/files

Before that patch the file was there, but not checked in / added, and hence a `make RELEASE...` removes the content from our `artifacts`, since it is not there

