### PR TITLE
Configurable trace export limit for upgrade tests

### DIFF
--- a/test/upgrade/prober/configuration.go
+++ b/test/upgrade/prober/configuration.go
@@ -53,6 +53,8 @@ const (
 	prefix = "eventing_upgrade_tests"
 
 	forwarderTargetFmt = "http://" + receiver.Name + ".%s.svc.cluster.local"
+
+	defaultTraceExportLimit = 100
 )
 
 var (
@@ -66,11 +68,12 @@ type DuplicateAction string
 // Config represents a configuration for prober.
 type Config struct {
 	Wathola
-	Interval     time.Duration
-	Serving      ServingConfig
-	FailOnErrors bool
-	OnDuplicate  DuplicateAction
-	Ctx          context.Context
+	Interval         time.Duration
+	Serving          ServingConfig
+	FailOnErrors     bool
+	OnDuplicate      DuplicateAction
+	Ctx              context.Context
+	TraceExportLimit int
 }
 
 // Wathola represents options related strictly to wathola testing tool.
@@ -119,6 +122,7 @@ func NewConfig() (*Config, error) {
 			Use:         false,
 			ScaleToZero: true,
 		},
+		TraceExportLimit: defaultTraceExportLimit,
 		Wathola: Wathola{
 			ImageResolver: pkgTest.ImagePath,
 			ConfigToml: ConfigToml{

--- a/test/upgrade/prober/verify.go
+++ b/test/upgrade/prober/verify.go
@@ -48,7 +48,6 @@ const (
 	jobWaitInterval     = time.Second
 	jobWaitTimeout      = 10 * time.Minute
 	stepEventMsgPattern = "event #([0-9]+).*"
-	exportTraceLimit    = 100
 )
 
 // Verify will verify prober state after finished has been sent.
@@ -114,7 +113,7 @@ func (p *prober) Finish() {
 }
 
 func (p *prober) exportStepEventTrace(i int, msg string) {
-	if i > exportTraceLimit {
+	if i > p.config.TraceExportLimit {
 		return
 	}
 	stepNo := p.getStepNoFromMsg(msg)


### PR DESCRIPTION
Backport of https://github.com/knative/eventing/commit/e63b13c341aa6722c5619f32ff4b0fabe661767a

The number of exported Zipkin traces for each test is now configurable. The default value is 100 but can be configured in this way:
```
export EVENTING_UPGRADE_TESTS_TRACEEXPORTLIMIT=XX
```

When there are multiple upgrade tests running in parallel and there are duplicate events in each of them collecting traces might take too long and cause test suite timeouts.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic -->
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed. -->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in https://github.com/knative/docs.
-->