### PR TITLE
[release-v1.8] Remove the knative- prefix from the release/version labels

### DIFF
--- a/openshift/release/artifacts/eventing-core.yaml
+++ b/openshift/release/artifacts/eventing-core.yaml
@@ -17,8 +17,8 @@ kind: Namespace
 metadata:
   name: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 ---
 # Copyright 2019 The Knative Authors
@@ -41,8 +41,8 @@ kind: ClusterRole
 metadata:
   name: addressable-resolver
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
@@ -57,9 +57,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: service-addressable-resolver
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
@@ -79,9 +79,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: serving-addressable-resolver
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
@@ -104,9 +104,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: channel-addressable-resolver
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
@@ -133,9 +133,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: broker-addressable-resolver
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
@@ -156,9 +156,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flows-addressable-resolver
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
@@ -193,8 +193,8 @@ kind: ClusterRole
 metadata:
   name: eventing-broker-filter
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -222,8 +222,8 @@ kind: ClusterRole
 metadata:
   name: eventing-broker-ingress
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -242,8 +242,8 @@ kind: ClusterRole
 metadata:
   name: eventing-config-reader
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -275,8 +275,8 @@ kind: ClusterRole
 metadata:
   name: channelable-manipulator
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
@@ -291,9 +291,9 @@ kind: ClusterRole
 metadata:
   name: meta-channelable-manipulator
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     duck.knative.dev/channelable: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 # Do not use this role directly. These rules will be added to the "channelable-manipulator" role.
 rules:
@@ -330,9 +330,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-eventing-namespaced-admin
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["eventing.knative.dev"]
@@ -344,9 +344,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-messaging-namespaced-admin
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["messaging.knative.dev"]
@@ -358,9 +358,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-flows-namespaced-admin
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["flows.knative.dev"]
@@ -372,9 +372,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-sources-namespaced-admin
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["sources.knative.dev"]
@@ -386,9 +386,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-bindings-namespaced-admin
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["bindings.knative.dev"]
@@ -401,8 +401,8 @@ metadata:
   name: knative-eventing-namespaced-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.knative.dev", "flows.knative.dev", "bindings.knative.dev"]
@@ -415,8 +415,8 @@ metadata:
   name: knative-eventing-namespaced-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.knative.dev", "flows.knative.dev", "bindings.knative.dev"]
@@ -442,8 +442,8 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-controller
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -588,8 +588,8 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-pingsource-mt-adapter
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -656,8 +656,8 @@ kind: ClusterRole
 metadata:
   name: podspecable-binding
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
@@ -672,9 +672,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: builtin-podspecable-binding
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     duck.knative.dev/podspecable: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 # Do not use this role directly. These rules will be added to the "podspecable-binding role.
 rules:
@@ -721,8 +721,8 @@ kind: ClusterRole
 metadata:
   name: source-observer
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
@@ -737,9 +737,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: eventing-sources-source-observer
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     duck.knative.dev/source: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 # Do not use this role directly. These rules will be added to the "source-observer" role.
 rules:
@@ -774,8 +774,8 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-sources-controller
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -866,8 +866,8 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-webhook
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 rules:
   # For watching logging configuration and getting certs.
@@ -985,8 +985,8 @@ metadata:
   namespace: knative-eventing
   name: knative-eventing-webhook
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 rules:
   # For manipulating certs into secrets.
@@ -1022,8 +1022,8 @@ metadata:
   name: eventing-controller
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 
 ---
@@ -1033,8 +1033,8 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -1052,8 +1052,8 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-resolver
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -1071,8 +1071,8 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-source-observer
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -1090,8 +1090,8 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-sources-controller
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -1109,8 +1109,8 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-manipulator
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -1141,8 +1141,8 @@ metadata:
   name: pingsource-mt-adapter
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 
 ---
@@ -1151,8 +1151,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-pingsource-mt-adapter
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -1183,8 +1183,8 @@ metadata:
   name: eventing-webhook
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 ---
 
@@ -1193,8 +1193,8 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-webhook
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -1213,8 +1213,8 @@ metadata:
   namespace: knative-eventing
   name: eventing-webhook
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -1232,8 +1232,8 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-webhook-resolver
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -1251,8 +1251,8 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-webhook-podspecable-binding
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -1282,11 +1282,11 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
   annotations:
     # TODO add schemas and descriptions
@@ -1497,10 +1497,10 @@ kind: CustomResourceDefinition
 metadata:
   name: brokers.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
@@ -1663,11 +1663,11 @@ kind: CustomResourceDefinition
 metadata:
   name: channels.messaging.knative.dev
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 spec:
   group: messaging.knative.dev
@@ -1937,11 +1937,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
   name: containersources.sources.knative.dev
 spec:
@@ -2090,9 +2090,9 @@ kind: CustomResourceDefinition
 metadata:
   name: eventtypes.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
@@ -2238,10 +2238,10 @@ kind: CustomResourceDefinition
 metadata:
   name: parallels.flows.knative.dev
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 spec:
   group: flows.knative.dev
@@ -2573,11 +2573,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
   annotations:
     # TODO add schemas and descriptions
@@ -2793,10 +2793,10 @@ kind: CustomResourceDefinition
 metadata:
   name: sequences.flows.knative.dev
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 spec:
   group: flows.knative.dev
@@ -3112,12 +3112,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     duck.knative.dev/binding: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
   name: sinkbindings.sources.knative.dev
 spec:
@@ -3308,9 +3308,9 @@ kind: CustomResourceDefinition
 metadata:
   name: subscriptions.messaging.knative.dev
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 spec:
   group: messaging.knative.dev
@@ -3519,9 +3519,9 @@ kind: CustomResourceDefinition
 metadata:
   name: triggers.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
@@ -3704,8 +3704,8 @@ metadata:
   name: config-br-default-channel
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 data:
   channel-template-spec: |
@@ -3732,8 +3732,8 @@ metadata:
   name: config-br-defaults
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 data:
   # Configures the default for any Broker that does not specify a spec.config or Broker class.
@@ -3769,10 +3769,10 @@ metadata:
   name: config-features
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 data:
   # ALPHA feature: The kreference-group allows you to use the Group field in KReferences.
@@ -3820,7 +3820,7 @@ metadata:
   name: config-kreference-mapping
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
   annotations:
@@ -3868,10 +3868,10 @@ metadata:
   name: config-ping-defaults
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
   annotations:
     knative.dev/example-checksum: "9185c153"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 data:
   _example: |
@@ -3914,8 +3914,8 @@ metadata:
   name: config-sugar
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "62dfac6f"
@@ -3951,8 +3951,8 @@ metadata:
   name: default-ch-webhook
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 data:
   # Configuration for defaulting channels that do not specify CRD implementations.
@@ -3985,8 +3985,8 @@ metadata:
   name: eventing-webhook-certs
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 # The data is populated at install time.
 ---
@@ -4010,10 +4010,10 @@ metadata:
   name: eventing-controller
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     knative.dev/high-availability: "true"
     app.kubernetes.io/component: eventing-controller
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
@@ -4023,9 +4023,9 @@ spec:
     metadata:
       labels:
         app: eventing-controller
-        eventing.knative.dev/release: knative-v1.8.0
+        eventing.knative.dev/release: v1.8
         app.kubernetes.io/component: eventing-controller
-        app.kubernetes.io/version: knative-v1.8.0
+        app.kubernetes.io/version: v1.8
         app.kubernetes.io/name: knative-eventing
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
@@ -4044,7 +4044,7 @@ spec:
       containers:
       - name: eventing-controller
         terminationMessagePolicy: FallbackToLogsOnError
-        image: registry.ci.openshift.org/openshift/knative-knative-v1.8.0:knative-eventing-controller
+        image: registry.ci.openshift.org/openshift/knative-v1.8:knative-eventing-controller
 
         resources:
           requests:
@@ -4064,7 +4064,7 @@ spec:
             value: knative.dev/eventing
           # APIServerSource
           - name: APISERVER_RA_IMAGE
-            value: registry.ci.openshift.org/openshift/knative-knative-v1.8.0:knative-eventing-apiserver-receive-adapter
+            value: registry.ci.openshift.org/openshift/knative-v1.8:knative-eventing-apiserver-receive-adapter
           - name: POD_NAME
             valueFrom:
               fieldRef:
@@ -4137,9 +4137,9 @@ metadata:
   name: pingsource-mt-adapter
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     app.kubernetes.io/component: pingsource-mt-adapter
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 spec:
   # when set to 0 (and only 0) will be set to 1 when the first PingSource is created.
@@ -4152,9 +4152,9 @@ spec:
     metadata:
       labels:
         <<: *labels
-        eventing.knative.dev/release: knative-v1.8.0
+        eventing.knative.dev/release: v1.8
         app.kubernetes.io/component: pingsource-mt-adapter
-        app.kubernetes.io/version: knative-v1.8.0
+        app.kubernetes.io/version: v1.8
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -4168,7 +4168,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: dispatcher
-          image: registry.ci.openshift.org/openshift/knative-knative-v1.8.0:knative-eventing-mtping
+          image: registry.ci.openshift.org/openshift/knative-v1.8:knative-eventing-mtping
           env:
             - name: SYSTEM_NAMESPACE
               value: ''
@@ -4242,8 +4242,8 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
@@ -4279,8 +4279,8 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
@@ -4312,8 +4312,8 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
@@ -4346,8 +4346,8 @@ metadata:
   name: eventing-webhook-certs
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 # The data is populated at install time.
 ---
@@ -4370,8 +4370,8 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: sinkbindings.webhook.sources.knative.dev
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
@@ -4404,9 +4404,9 @@ metadata:
   name: eventing-webhook
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
@@ -4417,9 +4417,9 @@ spec:
     metadata:
       labels:
         <<: *labels
-        eventing.knative.dev/release: knative-v1.8.0
+        eventing.knative.dev/release: v1.8
         app.kubernetes.io/component: eventing-webhook
-        app.kubernetes.io/version: knative-v1.8.0
+        app.kubernetes.io/version: v1.8
         app.kubernetes.io/name: knative-eventing
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
@@ -4441,7 +4441,7 @@ spec:
 
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: registry.ci.openshift.org/openshift/knative-knative-v1.8.0:knative-eventing-webhook
+        image: registry.ci.openshift.org/openshift/knative-v1.8:knative-eventing-webhook
 
         resources:
           requests:
@@ -4519,10 +4519,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     role: eventing-webhook
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
   name: eventing-webhook
   namespace: knative-eventing
@@ -4554,8 +4554,8 @@ metadata:
   name: config-leader-election
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "f7948630"
@@ -4615,10 +4615,10 @@ metadata:
   name: config-logging
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 data:
   # Common configuration for all Knative codebase
@@ -4669,10 +4669,10 @@ metadata:
   name: config-observability
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "f46cf09d"
@@ -4745,10 +4745,10 @@ metadata:
   name: config-tracing
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "0492ceb0"
@@ -4802,9 +4802,9 @@ metadata:
   name: eventing-webhook
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 spec:
   scaleTargetRef:
@@ -4828,9 +4828,9 @@ metadata:
   name: eventing-webhook
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 spec:
   minAvailable: 1

--- a/openshift/release/artifacts/eventing-crds.yaml
+++ b/openshift/release/artifacts/eventing-crds.yaml
@@ -18,11 +18,11 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
   annotations:
     # TODO add schemas and descriptions
@@ -233,10 +233,10 @@ kind: CustomResourceDefinition
 metadata:
   name: brokers.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
@@ -399,11 +399,11 @@ kind: CustomResourceDefinition
 metadata:
   name: channels.messaging.knative.dev
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 spec:
   group: messaging.knative.dev
@@ -673,11 +673,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
   name: containersources.sources.knative.dev
 spec:
@@ -826,9 +826,9 @@ kind: CustomResourceDefinition
 metadata:
   name: eventtypes.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
@@ -974,10 +974,10 @@ kind: CustomResourceDefinition
 metadata:
   name: parallels.flows.knative.dev
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 spec:
   group: flows.knative.dev
@@ -1309,11 +1309,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
   annotations:
     # TODO add schemas and descriptions
@@ -1529,10 +1529,10 @@ kind: CustomResourceDefinition
 metadata:
   name: sequences.flows.knative.dev
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 spec:
   group: flows.knative.dev
@@ -1848,12 +1848,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     duck.knative.dev/binding: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
   name: sinkbindings.sources.knative.dev
 spec:
@@ -2044,9 +2044,9 @@ kind: CustomResourceDefinition
 metadata:
   name: subscriptions.messaging.knative.dev
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 spec:
   group: messaging.knative.dev
@@ -2255,9 +2255,9 @@ kind: CustomResourceDefinition
 metadata:
   name: triggers.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev

--- a/openshift/release/artifacts/eventing-post-install.yaml
+++ b/openshift/release/artifacts/eventing-post-install.yaml
@@ -18,9 +18,9 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-post-install-job-role
   labels:
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
 rules:
   # Storage version upgrader needs to be able to patch CRDs.
   - apiGroups:
@@ -139,8 +139,8 @@ metadata:
   name: knative-eventing-post-install-job
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 ---
 
@@ -149,8 +149,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-post-install-job-role-binding
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -184,8 +184,8 @@ metadata:
     app: "storage-version-migration-eventing"
     app.kubernetes.io/name: knative-eventing
     app.kubernetes.io/component: storage-version-migration-job
-    app.kubernetes.io/version: knative-v1.8.0
-    eventing.knative.dev/release: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
+    eventing.knative.dev/release: v1.8
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 10
@@ -195,8 +195,8 @@ spec:
         app: "storage-version-migration-eventing"
         app.kubernetes.io/name: knative-eventing
         app.kubernetes.io/component: storage-version-migration-job
-        app.kubernetes.io/version: knative-v1.8.0
-        eventing.knative.dev/release: knative-v1.8.0
+        app.kubernetes.io/version: v1.8
+        eventing.knative.dev/release: v1.8
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
@@ -204,7 +204,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: migrate
-          image: registry.ci.openshift.org/openshift/knative-knative-v1.8.0:knative-eventing-migrate
+          image: registry.ci.openshift.org/openshift/knative-v1.8:knative-eventing-migrate
           args:
             - "apiserversources.sources.knative.dev"
             - "brokers.eventing.knative.dev"

--- a/openshift/release/artifacts/in-memory-channel.yaml
+++ b/openshift/release/artifacts/in-memory-channel.yaml
@@ -19,8 +19,8 @@ metadata:
   name: imc-controller
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -28,8 +28,8 @@ kind: ClusterRoleBinding
 metadata:
   name: imc-controller
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -46,8 +46,8 @@ metadata:
   namespace: knative-eventing
   name: imc-controller
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -63,8 +63,8 @@ kind: ClusterRoleBinding
 metadata:
   name: imc-controller-resolver
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -95,8 +95,8 @@ metadata:
   name: imc-dispatcher
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -104,8 +104,8 @@ kind: ClusterRoleBinding
 metadata:
   name: imc-dispatcher
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -136,9 +136,9 @@ metadata:
   name: config-imc-event-dispatcher
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     app.kubernetes.io/component: imc-controller
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 data:
   MaxIdleConnections: "1000"
@@ -164,10 +164,10 @@ metadata:
   name: imc-controller
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     knative.dev/high-availability: "true"
     app.kubernetes.io/component: imc-controller
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
@@ -179,7 +179,7 @@ spec:
       labels:
         <<: *labels
         app.kubernetes.io/component: imc-controller
-        app.kubernetes.io/version: knative-v1.8.0
+        app.kubernetes.io/version: v1.8
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -194,7 +194,7 @@ spec:
       enableServiceLinks: false
       containers:
       - name: controller
-        image: registry.ci.openshift.org/openshift/knative-knative-v1.8.0:knative-eventing-channel-controller
+        image: registry.ci.openshift.org/openshift/knative-v1.8:knative-eventing-channel-controller
         env:
           - name: WEBHOOK_NAME
             value: inmemorychannel-webhook
@@ -211,7 +211,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: DISPATCHER_IMAGE
-            value: registry.ci.openshift.org/openshift/knative-knative-v1.8.0:knative-eventing-channel-dispatcher
+            value: registry.ci.openshift.org/openshift/knative-v1.8:knative-eventing-channel-dispatcher
           - name: POD_NAME
             valueFrom:
               fieldRef:
@@ -258,9 +258,9 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: imc-controller
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
   name: inmemorychannel-webhook
   namespace: knative-eventing
 spec:
@@ -297,11 +297,11 @@ metadata:
   name: imc-dispatcher
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     messaging.knative.dev/channel: in-memory-channel
     messaging.knative.dev/role: dispatcher
     app.kubernetes.io/component: imc-dispatcher
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
@@ -336,10 +336,10 @@ metadata:
   name: imc-dispatcher
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     knative.dev/high-availability: "true"
     app.kubernetes.io/component: imc-dispatcher
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
@@ -351,7 +351,7 @@ spec:
       labels:
         <<: *labels
         app.kubernetes.io/component: imc-dispatcher
-        app.kubernetes.io/version: knative-v1.8.0
+        app.kubernetes.io/version: v1.8
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -366,7 +366,7 @@ spec:
       enableServiceLinks: false
       containers:
       - name: dispatcher
-        image: registry.ci.openshift.org/openshift/knative-knative-v1.8.0:knative-eventing-channel-dispatcher
+        image: registry.ci.openshift.org/openshift/knative-v1.8:knative-eventing-channel-dispatcher
         readinessProbe: &probe
           failureThreshold: 3
           httpGet:
@@ -434,11 +434,11 @@ kind: CustomResourceDefinition
 metadata:
  name: inmemorychannels.messaging.knative.dev
  labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 spec:
   group: messaging.knative.dev
@@ -679,9 +679,9 @@ kind: ClusterRole
 metadata:
   name: imc-addressable-resolver
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
@@ -714,9 +714,9 @@ kind: ClusterRole
 metadata:
   name: imc-channelable-manipulator
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     duck.knative.dev/channelable: "true"
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 # Do not use this role directly. These rules will be added to the "channelable-manipulator" role.
 rules:
@@ -753,8 +753,8 @@ kind: ClusterRole
 metadata:
   name: imc-controller
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -894,8 +894,8 @@ kind: ClusterRole
 metadata:
   name: imc-dispatcher
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -965,8 +965,8 @@ metadata:
   namespace: knative-eventing
   name: knative-inmemorychannel-webhook
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 rules:
   # For manipulating certs into secrets.
@@ -1001,8 +1001,8 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: inmemorychannel.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 webhooks:
 - admissionReviewVersions: ["v1"]
@@ -1034,8 +1034,8 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.inmemorychannel.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 webhooks:
 - admissionReviewVersions: ["v1"]
@@ -1068,7 +1068,7 @@ metadata:
   name: inmemorychannel-webhook-certs
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 # The data is populated at install time.

--- a/openshift/release/artifacts/mt-channel-broker.yaml
+++ b/openshift/release/artifacts/mt-channel-broker.yaml
@@ -17,8 +17,8 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-mt-channel-broker-controller
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 rules:
   # Configs resources and status we care about.
@@ -59,8 +59,8 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-mt-broker-filter
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -100,8 +100,8 @@ metadata:
   name: mt-broker-filter
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 ---
 # Copyright 2020 The Knative Authors
@@ -122,8 +122,8 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-mt-broker-ingress
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -162,8 +162,8 @@ metadata:
   name: mt-broker-ingress
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 ---
 # Copyright 2020 The Knative Authors
@@ -185,8 +185,8 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-mt-channel-broker-controller
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -216,8 +216,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-mt-broker-filter
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -247,8 +247,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-mt-broker-ingress
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
-    app.kubernetes.io/version: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -279,9 +279,9 @@ metadata:
   name: mt-broker-filter
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     app.kubernetes.io/component: broker-filter
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
@@ -291,9 +291,9 @@ spec:
     metadata:
       labels:
         eventing.knative.dev/brokerRole: filter
-        eventing.knative.dev/release: knative-v1.8.0
+        eventing.knative.dev/release: v1.8
         app.kubernetes.io/component: broker-filter
-        app.kubernetes.io/version: knative-v1.8.0
+        app.kubernetes.io/version: v1.8
         app.kubernetes.io/name: knative-eventing
     spec:
       serviceAccountName: mt-broker-filter
@@ -301,7 +301,7 @@ spec:
       containers:
       - name: filter
         terminationMessagePolicy: FallbackToLogsOnError
-        image: registry.ci.openshift.org/openshift/knative-knative-v1.8.0:knative-eventing-mtbroker-filter
+        image: registry.ci.openshift.org/openshift/knative-v1.8:knative-eventing-mtbroker-filter
         readinessProbe: &probe
           failureThreshold: 3
           httpGet:
@@ -368,9 +368,9 @@ kind: Service
 metadata:
   labels:
     eventing.knative.dev/brokerRole: filter
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     app.kubernetes.io/component: broker-filter
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
   name: broker-filter
   namespace: knative-eventing
@@ -407,9 +407,9 @@ metadata:
   name: mt-broker-ingress
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     app.kubernetes.io/component: broker-ingress
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
@@ -419,9 +419,9 @@ spec:
     metadata:
       labels:
         eventing.knative.dev/brokerRole: ingress
-        eventing.knative.dev/release: knative-v1.8.0
+        eventing.knative.dev/release: v1.8
         app.kubernetes.io/component: broker-ingress
-        app.kubernetes.io/version: knative-v1.8.0
+        app.kubernetes.io/version: v1.8
         app.kubernetes.io/name: knative-eventing
     spec:
       serviceAccountName: mt-broker-ingress
@@ -429,7 +429,7 @@ spec:
       containers:
       - name: ingress
         terminationMessagePolicy: FallbackToLogsOnError
-        image: registry.ci.openshift.org/openshift/knative-knative-v1.8.0:knative-eventing-mtbroker-ingress
+        image: registry.ci.openshift.org/openshift/knative-v1.8:knative-eventing-mtbroker-ingress
         readinessProbe: &probe
           failureThreshold: 3
           httpGet:
@@ -496,9 +496,9 @@ kind: Service
 metadata:
   labels:
     eventing.knative.dev/brokerRole: ingress
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     app.kubernetes.io/component: broker-ingress
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
   name: broker-ingress
   namespace: knative-eventing
@@ -535,9 +535,9 @@ metadata:
   name: mt-broker-controller
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: knative-v1.8.0
+    eventing.knative.dev/release: v1.8
     app.kubernetes.io/component: mt-broker-controller
-    app.kubernetes.io/version: knative-v1.8.0
+    app.kubernetes.io/version: v1.8
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
@@ -547,9 +547,9 @@ spec:
     metadata:
       labels:
         app: mt-broker-controller
-        eventing.knative.dev/release: knative-v1.8.0
+        eventing.knative.dev/release: v1.8
         app.kubernetes.io/component: broker-controller
-        app.kubernetes.io/version: knative-v1.8.0
+        app.kubernetes.io/version: v1.8
         app.kubernetes.io/name: knative-eventing
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
@@ -568,7 +568,7 @@ spec:
       containers:
       - name: mt-broker-controller
         terminationMessagePolicy: FallbackToLogsOnError
-        image: registry.ci.openshift.org/openshift/knative-knative-v1.8.0:knative-eventing-mtchannel-broker
+        image: registry.ci.openshift.org/openshift/knative-v1.8:knative-eventing-mtchannel-broker
 
         resources:
           requests:


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Looks like the branch got wrongly created, b/c unlike to other branches, the `version` labels did include the `knative` prefix:
`app.kubernetes.io/version: knative-v1.8.0`

Also, this results in wrong names for the images on the registry:
`registry.ci.openshift.org/openshift/knative-knative-v1.8.0:knative-eventing-migrate`

It should be `knative-v1.8.0`, instead of `knative-knative-v1.8.0`, like on 1.6 branch, and earlier 


