### PR TITLE
[release-v1.6] BACKPORT: Fix PingSource adapter metrics

### DIFF
--- a/cmd/mtping/main.go
+++ b/cmd/mtping/main.go
@@ -24,7 +24,8 @@ import (
 )
 
 const (
-	component = "pingsource-mt-adapter"
+	component     = "pingsource-mt-adapter"
+	metricsPrefix = "pingsource"
 )
 
 func main() {
@@ -45,7 +46,9 @@ func main() {
 	ctx = adapter.WithConfigWatcherEnabled(ctx)
 	ctx = adapter.WithConfiguratorOptions(ctx, []adapter.ConfiguratorOption{
 		adapter.WithLoggerConfigurator(adapter.NewLoggerConfiguratorFromConfigMap(component)),
-		adapter.WithMetricsExporterConfigurator(adapter.NewMetricsExporterConfiguratorFromConfigMap(component)),
+		adapter.WithMetricsExporterConfigurator(adapter.NewMetricsExporterConfiguratorFromConfigMap(metricsPrefix,
+			adapter.WithMetricsExporterConfiguratorMetricsPort(9090),
+		)),
 		adapter.WithTracingConfigurator(adapter.NewTracingConfiguratorFromConfigMap()),
 		adapter.WithProfilerConfigurator(adapter.NewProfilerConfiguratorFromConfigMap()),
 		adapter.WithCloudEventsStatusReporterConfigurator(adapter.NewCloudEventsReporterConfiguratorFromConfigMap()),

--- a/pkg/adapter/v2/configurator_configmap.go
+++ b/pkg/adapter/v2/configurator_configmap.go
@@ -23,7 +23,6 @@ import (
 	"os"
 
 	"go.uber.org/zap"
-
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/logging/logkey"
 	"knative.dev/pkg/metrics"
@@ -106,9 +105,6 @@ func (c *loggerConfiguratorFromConfigMap) CreateLogger(ctx context.Context) *zap
 
 	cmw := ConfigWatcherFromContext(ctx)
 	cmw.Watch(c.configMapName, logging.UpdateLevelFromConfigMap(logger, atomicLevel, c.component))
-	if err := cmw.Start(ctx.Done()); err != nil {
-		logger.Fatalw("Failed to start configuration manager", zap.Error(err))
-	}
 
 	return logger
 }
@@ -132,6 +128,7 @@ type metricsExporterConfiguratorFromConfigMap struct {
 	component     string
 	configMapName string
 	metricsDomain string
+	metricsPort   int
 }
 
 // MetricsExporterConfiguratorFromConfigMapOption for teawking the metrics exporter configurator.
@@ -151,11 +148,19 @@ func WithMetricsExporterConfiguratorMetricsDomain(domain string) MetricsExporter
 	}
 }
 
+// WithMetricsExporterConfiguratorMetricsPort sets the metrics exporter port for the metrics exporter configuration.
+func WithMetricsExporterConfiguratorMetricsPort(port int) MetricsExporterConfiguratorFromConfigMapOption {
+	return func(c *metricsExporterConfiguratorFromConfigMap) {
+		c.metricsPort = port
+	}
+}
+
 // NewMetricsExporterConfiguratorFromConfigMap returns a ConfigMap based metrics exporter configurator.
 func NewMetricsExporterConfiguratorFromConfigMap(component string, opts ...MetricsExporterConfiguratorFromConfigMapOption) MetricsExporterConfigurator {
 	c := &metricsExporterConfiguratorFromConfigMap{
 		component:     component,
 		configMapName: metrics.ConfigMapName(),
+		metricsPort:   defaultMetricsPort,
 	}
 
 	// metricDomainDefaulter is an AdapterDynamicconfig option that
@@ -185,7 +190,7 @@ func (c *metricsExporterConfiguratorFromConfigMap) SetupMetricsExporter(ctx cont
 	updateMetricsFunc, err := metrics.UpdateExporterFromConfigMapWithOpts(ctx, metrics.ExporterOptions{
 		Domain:         c.metricsDomain,
 		Component:      c.component,
-		PrometheusPort: defaultMetricsPort,
+		PrometheusPort: c.metricsPort,
 		Secrets:        SecretFetcher(ctx),
 	}, logger)
 	if err != nil {

--- a/pkg/adapter/v2/main.go
+++ b/pkg/adapter/v2/main.go
@@ -232,6 +232,12 @@ func MainWithInformers(ctx context.Context, component string, env EnvConfigAcces
 		ctx = leaderelection.WithStandardLeaderElectorBuilder(ctx, kubeclient.Get(ctx), *leConfig)
 	}
 
+	if cmw := ConfigWatcherFromContext(ctx); cmw != nil {
+		if err := cmw.Start(ctx.Done()); err != nil {
+			logger.Fatalw("Failed to start configuration manager", zap.Error(err))
+		}
+	}
+
 	wg := sync.WaitGroup{}
 
 	// Create and start controller is needed


### PR DESCRIPTION
The PingSource was not exporting metrics on the advertised port on the Deployment (metrics, 9090) but it was using 9092.

In addition any component using the adapter/v2 code suffers from unexported metrics because the exporter was created only after an update to `config-observability` since the watcher was started before the observer was registered as side effect of calling `CreateLogger`.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>