### PR TITLE
[release-v1.8] Apply patches to make OCP 4.8 -> 4.11 work

### DIFF
--- a/config/brokers/mt-channel-broker/deployments/broker-filter.yaml
+++ b/config/brokers/mt-channel-broker/deployments/broker-filter.yaml
@@ -97,8 +97,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
 
 ---
 

--- a/config/brokers/mt-channel-broker/deployments/broker-ingress.yaml
+++ b/config/brokers/mt-channel-broker/deployments/broker-ingress.yaml
@@ -97,8 +97,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
 
 ---
 

--- a/config/brokers/mt-channel-broker/deployments/controller.yaml
+++ b/config/brokers/mt-channel-broker/deployments/controller.yaml
@@ -81,8 +81,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/channels/in-memory-channel/deployments/controller.yaml
+++ b/config/channels/in-memory-channel/deployments/controller.yaml
@@ -78,8 +78,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/channels/in-memory-channel/deployments/dispatcher.yaml
+++ b/config/channels/in-memory-channel/deployments/dispatcher.yaml
@@ -95,5 +95,3 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault

--- a/config/core/deployments/controller.yaml
+++ b/config/core/deployments/controller.yaml
@@ -97,8 +97,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
 
         livenessProbe:
           httpGet:

--- a/config/core/deployments/pingsource-mt-adapter.yaml
+++ b/config/core/deployments/pingsource-mt-adapter.yaml
@@ -99,7 +99,5 @@ spec:
             capabilities:
               drop:
               - ALL
-            seccompProfile:
-              type: RuntimeDefault
 
       serviceAccountName: pingsource-mt-adapter

--- a/config/core/deployments/webhook-hpa.yaml
+++ b/config/core/deployments/webhook-hpa.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: autoscaling/v2
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: eventing-webhook

--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -101,8 +101,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
 
         ports:
         - name: https-webhook

--- a/config/post-install/storage-version-migrator.yaml
+++ b/config/post-install/storage-version-migrator.yaml
@@ -62,5 +62,3 @@ spec:
             capabilities:
               drop:
               - ALL
-            seccompProfile:
-              type: RuntimeDefault

--- a/config/tools/appender/appender.yaml
+++ b/config/tools/appender/appender.yaml
@@ -35,5 +35,3 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault

--- a/config/tools/event-display/event-display.yaml
+++ b/config/tools/event-display/event-display.yaml
@@ -32,5 +32,3 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault

--- a/config/tools/heartbeats/heartbeats.yaml
+++ b/config/tools/heartbeats/heartbeats.yaml
@@ -34,8 +34,6 @@ spec:
             capabilities:
               drop:
               - ALL
-            seccompProfile:
-              type: RuntimeDefault
 
   sink:
     ref:

--- a/config/tools/recordevents/recordevents.yaml
+++ b/config/tools/recordevents/recordevents.yaml
@@ -44,5 +44,3 @@ spec:
         capabilities:
           drop:
           - ALL
-        seccompProfile:
-          type: RuntimeDefault

--- a/config/tools/websocket-source/websocket-source.yaml
+++ b/config/tools/websocket-source/websocket-source.yaml
@@ -30,8 +30,6 @@ spec:
             capabilities:
               drop:
               - ALL
-            seccompProfile:
-              type: RuntimeDefault
 
   sink:
     ref:

--- a/openshift/patches/keep_hpa_v2beta2_until_ocp_4.13.patch
+++ b/openshift/patches/keep_hpa_v2beta2_until_ocp_4.13.patch
@@ -1,0 +1,13 @@
+diff --git a/config/core/deployments/webhook-hpa.yaml b/config/core/deployments/webhook-hpa.yaml
+index 007f98d04..04d5fbfe3 100644
+--- a/config/core/deployments/webhook-hpa.yaml
++++ b/config/core/deployments/webhook-hpa.yaml
+@@ -12,7 +12,7 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
+-apiVersion: autoscaling/v2
++apiVersion: autoscaling/v2beta2
+ kind: HorizontalPodAutoscaler
+ metadata:
+   name: eventing-webhook

--- a/openshift/patches/remove_seccompProfile.patch
+++ b/openshift/patches/remove_seccompProfile.patch
@@ -1,0 +1,166 @@
+diff --git a/config/brokers/mt-channel-broker/deployments/broker-filter.yaml b/config/brokers/mt-channel-broker/deployments/broker-filter.yaml
+index 924c132fd..49d53ab9e 100644
+--- a/config/brokers/mt-channel-broker/deployments/broker-filter.yaml
++++ b/config/brokers/mt-channel-broker/deployments/broker-filter.yaml
+@@ -97,8 +97,6 @@ spec:
+           capabilities:
+             drop:
+             - ALL
+-          seccompProfile:
+-            type: RuntimeDefault
+ 
+ ---
+ 
+diff --git a/config/brokers/mt-channel-broker/deployments/broker-ingress.yaml b/config/brokers/mt-channel-broker/deployments/broker-ingress.yaml
+index d8f5ab9a2..7099f5689 100644
+--- a/config/brokers/mt-channel-broker/deployments/broker-ingress.yaml
++++ b/config/brokers/mt-channel-broker/deployments/broker-ingress.yaml
+@@ -97,8 +97,6 @@ spec:
+           capabilities:
+             drop:
+             - ALL
+-          seccompProfile:
+-            type: RuntimeDefault
+ 
+ ---
+ 
+diff --git a/config/brokers/mt-channel-broker/deployments/controller.yaml b/config/brokers/mt-channel-broker/deployments/controller.yaml
+index d4e853b7c..a0eb8583b 100644
+--- a/config/brokers/mt-channel-broker/deployments/controller.yaml
++++ b/config/brokers/mt-channel-broker/deployments/controller.yaml
+@@ -81,8 +81,6 @@ spec:
+           capabilities:
+             drop:
+             - ALL
+-          seccompProfile:
+-            type: RuntimeDefault
+ 
+         ports:
+         - name: metrics
+diff --git a/config/channels/in-memory-channel/deployments/controller.yaml b/config/channels/in-memory-channel/deployments/controller.yaml
+index 42ef5e957..17ed17d7f 100644
+--- a/config/channels/in-memory-channel/deployments/controller.yaml
++++ b/config/channels/in-memory-channel/deployments/controller.yaml
+@@ -78,8 +78,6 @@ spec:
+           capabilities:
+             drop:
+             - ALL
+-          seccompProfile:
+-            type: RuntimeDefault
+ 
+         ports:
+         - name: metrics
+diff --git a/config/channels/in-memory-channel/deployments/dispatcher.yaml b/config/channels/in-memory-channel/deployments/dispatcher.yaml
+index fc88c6697..240d2b662 100644
+--- a/config/channels/in-memory-channel/deployments/dispatcher.yaml
++++ b/config/channels/in-memory-channel/deployments/dispatcher.yaml
+@@ -95,5 +95,3 @@ spec:
+           capabilities:
+             drop:
+             - ALL
+-          seccompProfile:
+-            type: RuntimeDefault
+diff --git a/config/core/deployments/controller.yaml b/config/core/deployments/controller.yaml
+index d1a38ea62..ddf1259c6 100644
+--- a/config/core/deployments/controller.yaml
++++ b/config/core/deployments/controller.yaml
+@@ -97,8 +97,6 @@ spec:
+           capabilities:
+             drop:
+             - ALL
+-          seccompProfile:
+-            type: RuntimeDefault
+ 
+         livenessProbe:
+           httpGet:
+diff --git a/config/core/deployments/pingsource-mt-adapter.yaml b/config/core/deployments/pingsource-mt-adapter.yaml
+index c48b4ad21..ccf1af351 100644
+--- a/config/core/deployments/pingsource-mt-adapter.yaml
++++ b/config/core/deployments/pingsource-mt-adapter.yaml
+@@ -99,7 +99,5 @@ spec:
+             capabilities:
+               drop:
+               - ALL
+-            seccompProfile:
+-              type: RuntimeDefault
+ 
+       serviceAccountName: pingsource-mt-adapter
+diff --git a/config/core/deployments/webhook.yaml b/config/core/deployments/webhook.yaml
+index 2ba3c1190..1995a25c3 100644
+--- a/config/core/deployments/webhook.yaml
++++ b/config/core/deployments/webhook.yaml
+@@ -101,8 +101,6 @@ spec:
+           capabilities:
+             drop:
+             - ALL
+-          seccompProfile:
+-            type: RuntimeDefault
+ 
+         ports:
+         - name: https-webhook
+diff --git a/config/post-install/storage-version-migrator.yaml b/config/post-install/storage-version-migrator.yaml
+index c2d6d836f..8fcc812e7 100644
+--- a/config/post-install/storage-version-migrator.yaml
++++ b/config/post-install/storage-version-migrator.yaml
+@@ -62,5 +62,3 @@ spec:
+             capabilities:
+               drop:
+               - ALL
+-            seccompProfile:
+-              type: RuntimeDefault
+diff --git a/config/tools/appender/appender.yaml b/config/tools/appender/appender.yaml
+index 169405198..63e9db6fc 100644
+--- a/config/tools/appender/appender.yaml
++++ b/config/tools/appender/appender.yaml
+@@ -35,5 +35,3 @@ spec:
+           capabilities:
+             drop:
+             - ALL
+-          seccompProfile:
+-            type: RuntimeDefault
+diff --git a/config/tools/event-display/event-display.yaml b/config/tools/event-display/event-display.yaml
+index 57538dcc9..fc824255e 100644
+--- a/config/tools/event-display/event-display.yaml
++++ b/config/tools/event-display/event-display.yaml
+@@ -32,5 +32,3 @@ spec:
+           capabilities:
+             drop:
+             - ALL
+-          seccompProfile:
+-            type: RuntimeDefault
+diff --git a/config/tools/heartbeats/heartbeats.yaml b/config/tools/heartbeats/heartbeats.yaml
+index c0753a3c8..1c0ba857e 100644
+--- a/config/tools/heartbeats/heartbeats.yaml
++++ b/config/tools/heartbeats/heartbeats.yaml
+@@ -34,8 +34,6 @@ spec:
+             capabilities:
+               drop:
+               - ALL
+-            seccompProfile:
+-              type: RuntimeDefault
+ 
+   sink:
+     ref:
+diff --git a/config/tools/recordevents/recordevents.yaml b/config/tools/recordevents/recordevents.yaml
+index 3661a16c8..23371182d 100644
+--- a/config/tools/recordevents/recordevents.yaml
++++ b/config/tools/recordevents/recordevents.yaml
+@@ -44,5 +44,3 @@ spec:
+         capabilities:
+           drop:
+           - ALL
+-        seccompProfile:
+-          type: RuntimeDefault
+diff --git a/config/tools/websocket-source/websocket-source.yaml b/config/tools/websocket-source/websocket-source.yaml
+index 844c39845..1a590f667 100644
+--- a/config/tools/websocket-source/websocket-source.yaml
++++ b/config/tools/websocket-source/websocket-source.yaml
+@@ -30,8 +30,6 @@ spec:
+             capabilities:
+               drop:
+               - ALL
+-            seccompProfile:
+-              type: RuntimeDefault
+ 
+   sink:
+     ref:

--- a/openshift/release/artifacts/eventing-core.yaml
+++ b/openshift/release/artifacts/eventing-core.yaml
@@ -4089,8 +4089,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
 
         livenessProbe:
           httpGet:
@@ -4218,8 +4216,6 @@ spec:
             capabilities:
               drop:
               - ALL
-            seccompProfile:
-              type: RuntimeDefault
 
       serviceAccountName: pingsource-mt-adapter
 ---
@@ -4487,8 +4483,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
 
         ports:
         - name: https-webhook
@@ -4796,7 +4790,7 @@ data:
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: autoscaling/v2
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: eventing-webhook

--- a/openshift/release/artifacts/eventing-post-install.yaml
+++ b/openshift/release/artifacts/eventing-post-install.yaml
@@ -225,5 +225,3 @@ spec:
             capabilities:
               drop:
               - ALL
-            seccompProfile:
-              type: RuntimeDefault

--- a/openshift/release/artifacts/in-memory-channel.yaml
+++ b/openshift/release/artifacts/in-memory-channel.yaml
@@ -224,8 +224,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
 
         ports:
         - name: metrics
@@ -413,8 +411,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
 ---
 # Copyright 2019 The Knative Authors
 #

--- a/openshift/release/artifacts/mt-channel-broker.yaml
+++ b/openshift/release/artifacts/mt-channel-broker.yaml
@@ -358,8 +358,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
 
 ---
 
@@ -486,8 +484,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
 
 ---
 
@@ -598,8 +594,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
 
         ports:
         - name: metrics


### PR DESCRIPTION
Currently  `48-test-e2e-aws-ocp-48` test is failing, because the eventing-operator does not come up cause of `failed to apply non rbac manifest: no matches for kind "HorizontalPodAutoscaler" in version "autoscaling/v2"`

https://github.com/openshift/knative-eventing/pull/1928 addressed it and set the apiVersion for HPA to autoscaling/v2beta2. This PR cherry-picks these changes into the 1.8 branch.