### PR TITLE
[release-v1.6] set scheduler logging to debug

### DIFF
--- a/pkg/scheduler/statefulset/scheduler.go
+++ b/pkg/scheduler/statefulset/scheduler.go
@@ -170,7 +170,7 @@ func (s *StatefulSetScheduler) scheduleVPod(vpod scheduler.VPod) ([]duckv1alpha1
 	// Quite an expensive operation but safe and simple.
 	state, err := s.stateAccessor.State(s.reserved)
 	if err != nil {
-		logger.Info("error while refreshing scheduler state (will retry)", zap.Error(err))
+		logger.Debug("error while refreshing scheduler state (will retry)", zap.Error(err))
 		return nil, err
 	}
 


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Manual port of upstream's #6705 

NOTE: this is not a release blocker, but if we pick it up (or in a `.z` release), thats good enough
