### PR TITLE
Update remove seccompProfile patch

### DIFF
--- a/openshift/patches/remove_seccompProfile.patch
+++ b/openshift/patches/remove_seccompProfile.patch
@@ -164,3 +164,27 @@ index 844c39845..1a590f667 100644
  
    sink:
      ref:
+diff --git a/pkg/reconciler/apiserversource/resources/receive_adapter.go b/pkg/reconciler/apiserversource/resources/receive_adapter.go
+index 83c784317..38ad0b22b 100644
+--- a/pkg/reconciler/apiserversource/resources/receive_adapter.go
++++ b/pkg/reconciler/apiserversource/resources/receive_adapter.go
+@@ -108,7 +108,6 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) (*appsv1.Deployment, error) {
+ 								ReadOnlyRootFilesystem:   ptr.Bool(true),
+ 								RunAsNonRoot:             ptr.Bool(true),
+ 								Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+-								SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+ 							},
+ 						},
+ 					},
+diff --git a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+index 777ec5769..f8e35fd13 100644
+--- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
++++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+@@ -169,7 +169,6 @@ func TestMakeReceiveAdapters(t *testing.T) {
+ 								ReadOnlyRootFilesystem:   ptr.Bool(true),
+ 								RunAsNonRoot:             ptr.Bool(true),
+ 								Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+-								SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+ 							},
+ 						},
+ 					},


### PR DESCRIPTION
As we have the current CI issues (https://github.com/openshift-knative/eventing/pull/149#issuecomment-1461626945)

```
    - lastTransitionTime: "2023-03-09T01:56:59Z"
      lastUpdateTime: "2023-03-09T01:56:59Z"
      message: 'pods "apiserversource-apiserversourcebedf0f900c506331f8659412fd1wtdn8"
        is forbidden: unable to validate against any security context constraint:
        [pod.metadata.annotations.container.seccomp.security.alpha.kubernetes.io/receive-adapter:
        Forbidden: seccomp may not be set provider "anyuid": Forbidden: not usable
        by user or serviceaccount provider "nonroot": Forbidden: not usable by user
        or serviceaccount provider "hostmount-anyuid": Forbidden: not usable by user
        or serviceaccount provider "machine-api-termination-handler": Forbidden: not
        usable by user or serviceaccount provider "hostnetwork": Forbidden: not usable
        by user or serviceaccount provider "hostaccess": Forbidden: not usable by
        user or serviceaccount provider "node-exporter": Forbidden: not usable by
        user or serviceaccount provider "privileged": Forbidden: not usable by user
        or serviceaccount]'
      reason: FailedCreate
      status: "True"
      type: ReplicaFailure
```