### PR TITLE
Assign default value for release correctly

### DIFF
--- a/openshift/common.sh
+++ b/openshift/common.sh
@@ -11,7 +11,7 @@ function update_image_resolver_file() {
   echo $@
 
   local image_resolver_file=$1
-  local release=${2:"ci"}
+  local release=${2:-"ci"}
   declare -A images
 
   echo "Updating image resolver file ${image_resolver_file}"


### PR DESCRIPTION
As per title

Had the following error in Jenkins (e.g. [knative-nightly-ci-eventing#746](https://master-jenkins-csb-serverless-qe.apps.ocp-c1.prod.psi.redhat.com/job/ci/job/knative-nightly-ci-eventing/746/console))
```
01:36:27  /home/jenkins/workspace/ci/knative-nightly-ci-eventing/knative/eventing/openshift/release/../images.yaml ci
01:36:27  ./openshift/release/../common.sh: line 14: 2: "ci": syntax error: operand expected (error token is ""ci"")
01:36:27  make: *** [Makefile:79: generate-release] Error 1
```