### PR TITLE
Use correct env in CI for heartbeats image ref

### DIFF
--- a/openshift/common.sh
+++ b/openshift/common.sh
@@ -21,7 +21,7 @@ function update_image_resolver_file() {
     image_prefix="registry.ci.openshift.org/openshift/knative-release-next:knative-eventing"
 
     images[knative.dev/eventing/test/test_images/print]=${KNATIVE_EVENTING_TEST_PRINT:-"${image_prefix}-print"}
-    images[knative.dev/eventing/cmd/heartbeats]=${KNATIVE_EVENTING_TEST_HEARTBEATS:-"${image_prefix}-heartbeats"}
+    images[knative.dev/eventing/cmd/heartbeats]=${KNATIVE_EVENTING_HEARTBEATS:-"${image_prefix}-heartbeats"}
     images[knative.dev/reconciler-test/cmd/eventshub]=${KNATIVE_EVENTING_TEST_EVENTSHUB:-"${image_prefix}-eventshub"}
   else
     image_prefix="registry.ci.openshift.org/openshift/knative-${release}:knative-eventing"


### PR DESCRIPTION
The `KNATIVE_EVENTING_TEST_HEARTBEATS` env ref was removed in https://github.com/openshift/release/pull/37160.