### PR TITLE
Use GOPATH env when calling openshift-knative/hack/cmd/generate

### DIFF
--- a/openshift/generate.sh
+++ b/openshift/generate.sh
@@ -6,7 +6,7 @@ repo_root_dir=$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..
 
 GO111MODULE=off go get -u github.com/openshift-knative/hack/cmd/generate
 
-generate \
+$(go env GOPATH)/bin/generate \
   --root-dir "${repo_root_dir}" \
   --generators dockerfile
 


### PR DESCRIPTION
Currently we have the CI issue for eventing nightly: 
```
./openshift/generate.sh: line 10: generate: command not found
```

This PR addresses it