### PR TITLE
Fail generate-release too, if subscript fails

### DIFF
--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 source $(dirname $0)/resolve.sh
 
 release=$(yq r openshift/project.yaml project.tag)


### PR DESCRIPTION
Currently CI jobs don't fail, when something in a subscript from generate-release.sh fails.
This PR addresses it.

/hold
until #167 merges