### PR TITLE
[release-v1.9] Replace heartbeats test image in rekt resources with midstream variant

### DIFF
--- a/test/rekt/resources/deployment/deployment.go
+++ b/test/rekt/resources/deployment/deployment.go
@@ -34,9 +34,9 @@ var yaml embed.FS
 func Install(name string) feature.StepFn {
 	cfg := map[string]interface{}{
 		"name":      name,
-		"selectors": map[string]string{"app": name},                                                         // default
-		"image":     "registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-heartbeats", // default
-		"port":      8080,                                                                                   // default
+		"selectors": map[string]string{"app": name},                                                      // default
+		"image":     "registry.ci.openshift.org/openshift/knative-v1.9:knative-eventing-test-heartbeats", // default
+		"port":      8080,                                                                                // default
 	}
 
 	return func(ctx context.Context, t feature.T) {

--- a/test/rekt/resources/deployment/deployment.go
+++ b/test/rekt/resources/deployment/deployment.go
@@ -35,7 +35,7 @@ func Install(name string) feature.StepFn {
 	cfg := map[string]interface{}{
 		"name":      name,
 		"selectors": map[string]string{"app": name},                                                      // default
-		"image":     "registry.ci.openshift.org/openshift/knative-v1.9:knative-eventing-test-heartbeats", // default
+		"image":     "registry.ci.openshift.org/openshift/knative-eventing-test-heartbeats:knative-v1.9", // default
 		"port":      8080,                                                                                // default
 	}
 

--- a/test/rekt/resources/deployment/deployment.go
+++ b/test/rekt/resources/deployment/deployment.go
@@ -34,9 +34,9 @@ var yaml embed.FS
 func Install(name string) feature.StepFn {
 	cfg := map[string]interface{}{
 		"name":      name,
-		"selectors": map[string]string{"app": name},                               // default
-		"image":     "gcr.io/knative-nightly/knative.dev/eventing/cmd/heartbeats", // default
-		"port":      8080,                                                         // default
+		"selectors": map[string]string{"app": name},                                                         // default
+		"image":     "registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-heartbeats", // default
+		"port":      8080,                                                                                   // default
 	}
 
 	return func(ctx context.Context, t feature.T) {

--- a/test/rekt/resources/job/job.go
+++ b/test/rekt/resources/job/job.go
@@ -34,7 +34,7 @@ var yaml embed.FS
 func Install(name string) feature.StepFn {
 	cfg := map[string]interface{}{
 		"name":  name,
-		"image": "gcr.io/knative-nightly/knative.dev/eventing/cmd/heartbeats", // default
+		"image": "registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-heartbeats", // default
 	}
 
 	return func(ctx context.Context, t feature.T) {

--- a/test/rekt/resources/job/job.go
+++ b/test/rekt/resources/job/job.go
@@ -34,7 +34,7 @@ var yaml embed.FS
 func Install(name string) feature.StepFn {
 	cfg := map[string]interface{}{
 		"name":  name,
-		"image": "registry.ci.openshift.org/openshift/knative-v1.9:knative-eventing-test-heartbeats", // default
+		"image": "registry.ci.openshift.org/openshift/knative-eventing-test-heartbeats:knative-v1.9", // default
 	}
 
 	return func(ctx context.Context, t feature.T) {

--- a/test/rekt/resources/job/job.go
+++ b/test/rekt/resources/job/job.go
@@ -34,7 +34,7 @@ var yaml embed.FS
 func Install(name string) feature.StepFn {
 	cfg := map[string]interface{}{
 		"name":  name,
-		"image": "registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-heartbeats", // default
+		"image": "registry.ci.openshift.org/openshift/knative-v1.9:knative-eventing-test-heartbeats", // default
 	}
 
 	return func(ctx context.Context, t feature.T) {


### PR DESCRIPTION
Same as https://github.com/openshift-knative/eventing/pull/170