### PR TITLE
[release-v1.9] Remove sanitize HTTP body for `knativeerrordata` extension (#6902)

### DIFF
--- a/pkg/channel/message_dispatcher_test.go
+++ b/pkg/channel/message_dispatcher_test.go
@@ -693,7 +693,7 @@ func TestDispatchMessage(t *testing.T) {
 					"traceparent":         {"ignored-value-header"},
 					"ce-abc":              {`"ce-abc-value"`},
 					"ce-knativeerrorcode": {strconv.Itoa(http.StatusBadRequest)},
-					"ce-knativeerrordata": {base64.StdEncoding.EncodeToString([]byte("destination multi-line response"))},
+					"ce-knativeerrordata": {base64.StdEncoding.EncodeToString([]byte("destination\n multi-line\n response"))},
 					"ce-id":               {"ignored-value-header"},
 					"ce-time":             {"2002-10-02T15:00:00Z"},
 					"ce-source":           {testCeSource},

--- a/test/rekt/features/channel/features.go
+++ b/test/rekt/features/channel/features.go
@@ -427,7 +427,6 @@ func channelSubscriberReturnedErrorWithData(createSubscriberFn func(ref *duckv1.
 	f.Setup("install sink", eventshub.Install(sink, eventshub.StartReceiver))
 
 	errorData := "<!doctype html>\n<html>\n<head>\n    <title>Error Page(tm)</title>\n</head>\n<body>\n<p>Quoth the server, 404!\n</body></html>"
-	sanitizeBodyData := sanitizeHTTPBody([]byte(errorData))
 	f.Setup("install failing receiver", eventshub.Install(failer,
 		eventshub.StartReceiver,
 		eventshub.DropFirstN(1),
@@ -461,7 +460,7 @@ func channelSubscriberReturnedErrorWithData(createSubscriberFn func(ref *duckv1.
 			return test.HasExtension("knativeerrorcode", "422")
 		},
 		func(ctx context.Context) test.EventMatcher {
-			return test.HasExtension("knativeerrordata", base64.StdEncoding.EncodeToString([]byte(sanitizeBodyData)))
+			return test.HasExtension("knativeerrordata", base64.StdEncoding.EncodeToString([]byte(errorData)))
 		},
 	))
 
@@ -481,36 +480,4 @@ func assertEnhancedWithKnativeErrorExtensions(sinkName string, matcherfns ...fun
 			assert.MatchEvent(matchers...),
 		)
 	}
-}
-
-func sanitizeHTTPBody(body []byte) string {
-	if !hasControlChars(body) {
-		return string(body)
-	}
-
-	sanitizedResponse := make([]byte, 0, len(body))
-	for _, v := range body {
-		if !isControl(v) {
-			sanitizedResponse = append(sanitizedResponse, v)
-		}
-	}
-	return string(sanitizedResponse)
-}
-
-func isControl(c byte) bool {
-	// US ASCII codes range for printable graphic characters and a space.
-	// http://www.columbia.edu/kermit/ascii.html
-	const asciiUnitSeparator = 31
-	const asciiRubout = 127
-
-	return int(c) < asciiUnitSeparator || int(c) > asciiRubout
-}
-
-func hasControlChars(data []byte) bool {
-	for _, v := range data {
-		if isControl(v) {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/knative/eventing/commit/66e8257b9c834f4456795562b38720e9de01ac0e