### PR TITLE
[release-v1.9] Generate release based on project.yaml metadata

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -15,5 +15,9 @@ RUN yum install -y kubectl httpd-tools
 
 RUN GOFLAGS='' go install github.com/mikefarah/yq/v3@latest
 
+# go install creates $GOPATH/.cache with root permissions, we delete it here
+# to avoid permission issues with the runtime users
+RUN rm -rf $GOPATH/.cache
+
 # Allow runtime users to add entries to /etc/passwd
 RUN chmod g+rw /etc/passwd

--- a/openshift/generate.sh
+++ b/openshift/generate.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 
 repo_root_dir=$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..
 
+"${repo_root_dir}/hack/update-deps.sh" || exit 1
+git apply "${repo_root_dir}/openshift/patches/005-k8s-min.patch"
+git apply "${repo_root_dir}/openshift/patches/018-rekt-test-override-kopublish.patch"
+git apply "${repo_root_dir}/openshift/patches/018-rekt-test-image-pod.patch"
+git apply "${repo_root_dir}/openshift/patches/020-mutemetrics.patch"
+
 GO111MODULE=off go get -u github.com/openshift-knative/hack/cmd/generate
 
 generate \

--- a/openshift/patches/018-rekt-test-image-changes.patch
+++ b/openshift/patches/018-rekt-test-image-changes.patch
@@ -71,16 +71,3 @@ index bc33ccdc2..03b03a071 100644
  	}
  	cfg := map[string]interface{}{
  		"name":      "foo",
-diff --git a/vendor/knative.dev/reconciler-test/pkg/eventshub/103-pod.yaml b/vendor/knative.dev/reconciler-test/pkg/eventshub/103-pod.yaml
-index 2b8ad28d3..e34319f57 100644
---- a/vendor/knative.dev/reconciler-test/pkg/eventshub/103-pod.yaml
-+++ b/vendor/knative.dev/reconciler-test/pkg/eventshub/103-pod.yaml
-@@ -47,7 +47,7 @@ spec:
-           {{ end }}
-         allowPrivilegeEscalation: {{ .containerSecurityContext.allowPrivilegeEscalation }}
-       {{ end }}
--      image: {{ .image }}
-+      image: registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-eventshub
-       imagePullPolicy: "IfNotPresent"
-       {{ if .withReadiness }}
-       readinessProbe:

--- a/openshift/patches/018-rekt-test-image-pod.patch
+++ b/openshift/patches/018-rekt-test-image-pod.patch
@@ -1,0 +1,13 @@
+diff --git a/vendor/knative.dev/reconciler-test/pkg/eventshub/103-pod.yaml b/vendor/knative.dev/reconciler-test/pkg/eventshub/103-pod.yaml
+index 2b8ad28d3..e34319f57 100644
+--- a/vendor/knative.dev/reconciler-test/pkg/eventshub/103-pod.yaml
++++ b/vendor/knative.dev/reconciler-test/pkg/eventshub/103-pod.yaml
+@@ -47,7 +47,7 @@ spec:
+           {{ end }}
+         allowPrivilegeEscalation: {{ .containerSecurityContext.allowPrivilegeEscalation }}
+       {{ end }}
+-      image: {{ .image }}
++      image: registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-eventshub
+       imagePullPolicy: "IfNotPresent"
+       {{ if .withReadiness }}
+       readinessProbe:

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -4,7 +4,7 @@ source $(dirname $0)/resolve.sh
 
 release=$1
 
-./openshift/generate.sh
+./openshift/generate.sh || exit 1
 
 artifacts_dir="openshift/release/artifacts"
 rm -rf $artifacts_dir
@@ -16,13 +16,10 @@ rm -rf config/channels/in-memory-channel/100-namespace.yaml
 rm -rf config/brokers/mt-channel-broker/deployments/hpa.yaml
 rm -rf config/brokers/mt-channel-broker/hpa.yaml
 
-if [ "$release" == "ci" ]; then
-    image_prefix="registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-"
-    tag=""
-else
-    image_prefix="registry.ci.openshift.org/openshift/knative-${release}:knative-eventing-"
-    tag=""
-fi
+release=$(yq r openshift/project.yaml project.tag)
+release=${release/knative-/}
+image_prefix="registry.ci.openshift.org/openshift/knative-${release}:knative-eventing-"
+tag=""
 
 eventing_core="${artifacts_dir}/eventing-core.yaml"
 eventing_crds="${artifacts_dir}/eventing-crds.yaml"


### PR DESCRIPTION
- This removes the need for `RELEASE=v1.9` in `make generate-release`
- Add the `hack/update-deps.sh` to generate-release to align vendor when generating code