### PR TITLE
Using proper versioned images for 1.9

### DIFF
--- a/test/rekt/features/apiserversource/data_plane.go
+++ b/test/rekt/features/apiserversource/data_plane.go
@@ -45,7 +45,7 @@ import (
 )
 
 const (
-	exampleImage = "registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-print"
+	exampleImage = "registry.ci.openshift.org/openshift/knative-v1.8:knative-eventing-test-print"
 )
 
 func DataPlane_SinkTypes() *feature.FeatureSet {

--- a/test/rekt/resources/containersource/containersource.yaml
+++ b/test/rekt/resources/containersource/containersource.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: heartbeats
-        image: registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-heartbeats
+        image: registry.ci.openshift.org/openshift/knative-v1.8:knative-eventing-test-heartbeats
         imagePullPolicy: IfNotPresent
         args:
         - {{ .args }}

--- a/test/rekt/resources/containersource/containersource_test.go
+++ b/test/rekt/resources/containersource/containersource_test.go
@@ -54,7 +54,7 @@ func Example_min() {
 	//     spec:
 	//       containers:
 	//       - name: heartbeats
-	//         image: registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-heartbeats
+	//         image: registry.ci.openshift.org/openshift/knative-v1.8:knative-eventing-test-heartbeats
 	//         imagePullPolicy: IfNotPresent
 	//         args:
 	//         - --period=1
@@ -116,7 +116,7 @@ func Example_full() {
 	//     spec:
 	//       containers:
 	//       - name: heartbeats
-	//         image: registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-heartbeats
+	//         image: registry.ci.openshift.org/openshift/knative-v1.8:knative-eventing-test-heartbeats
 	//         imagePullPolicy: IfNotPresent
 	//         args:
 	//         - --period=1

--- a/test/rekt/resources/flaker/flaker.yaml
+++ b/test/rekt/resources/flaker/flaker.yaml
@@ -29,7 +29,7 @@ spec:
   restartPolicy: "Never"
   containers:
     - name: flaker
-      image: registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-event-flaker
+      image: registry.ci.openshift.org/openshift/knative-v1.8:knative-eventing-test-event-flaker
       imagePullPolicy: "IfNotPresent"
       {{ if .containerSecurityContext }}
       securityContext:

--- a/test/rekt/resources/flaker/flaker_test.go
+++ b/test/rekt/resources/flaker/flaker_test.go
@@ -30,7 +30,7 @@ var yaml embed.FS
 func Example() {
 	ctx := testlog.NewContext()
 	images := map[string]string{
-		"registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-event-flaker": "gcr.io/knative-samples/helloworld-go",
+		"registry.ci.openshift.org/openshift/knative-v1.8:knative-eventing-test-event-flaker": "gcr.io/knative-samples/helloworld-go",
 	}
 	cfg := map[string]interface{}{
 		"name":      "foo",

--- a/vendor/knative.dev/reconciler-test/pkg/eventshub/103-pod.yaml
+++ b/vendor/knative.dev/reconciler-test/pkg/eventshub/103-pod.yaml
@@ -47,7 +47,7 @@ spec:
           {{ end }}
         allowPrivilegeEscalation: {{ .containerSecurityContext.allowPrivilegeEscalation }}
       {{ end }}
-      image: registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-eventshub
+      image: registry.ci.openshift.org/openshift/knative-v1.8:knative-eventing-test-eventshub
       imagePullPolicy: "IfNotPresent"
       {{ if .withReadiness }}
       readinessProbe:


### PR DESCRIPTION
This is not required for 1.10 because there we use the image mapping file.