### PR TITLE
SourceToSink and ChannelChain features support REKT parallelism

### DIFF
--- a/test/rekt/features/broker/source_to_sink.go
+++ b/test/rekt/features/broker/source_to_sink.go
@@ -56,13 +56,10 @@ func SourceToSink(brokerName string) *feature.Feature {
 
 	f.Setup("trigger goes ready", trigger.IsReady(via))
 
-	f.Setup("install source", func(ctx context.Context, t feature.T) {
-		u, err := broker.Address(ctx, brokerName)
-		if err != nil || u == nil {
-			t.Error("failed to get the address of the broker", brokerName, err)
-		}
-		eventshub.Install(source, eventshub.StartSenderURL(u.String()), eventshub.InputEvent(event))(ctx, t)
-	})
+	f.Requirement("install source", eventshub.Install(source,
+		eventshub.StartSenderToResource(broker.GVR(), brokerName),
+		eventshub.InputEvent(event),
+	))
 
 	f.Stable("broker as middleware").
 		Must("deliver an event",

--- a/test/rekt/features/channel/features.go
+++ b/test/rekt/features/channel/features.go
@@ -37,7 +37,6 @@ import (
 	"knative.dev/eventing/test/rekt/resources/channel_impl"
 	"knative.dev/eventing/test/rekt/resources/containersource"
 	"knative.dev/eventing/test/rekt/resources/delivery"
-	"knative.dev/eventing/test/rekt/resources/pingsource"
 	"knative.dev/eventing/test/rekt/resources/source"
 	"knative.dev/eventing/test/rekt/resources/subscription"
 )
@@ -52,12 +51,10 @@ func ChannelChain(length int, createSubscriberFn func(ref *duckv1.KReference, ur
 		name := feature.MakeRandomK8sName(fmt.Sprintf("channel-%04d", i))
 		channels = append(channels, name)
 		f.Setup("install channel", channel_impl.Install(name))
-		f.Requirement("channel is ready", channel_impl.IsReady(name))
+		f.Setup("channel is ready", channel_impl.IsReady(name))
 	}
 
 	f.Setup("install sink", eventshub.Install(sink, eventshub.StartReceiver))
-	// attach the first channel to the source
-	f.Setup("install containersource", containersource.Install(cs, pingsource.WithSink(channel_impl.AsRef(channels[0]), "")))
 
 	// use the rest for the chain
 	for i := 0; i < length; i++ {
@@ -74,7 +71,12 @@ func ChannelChain(length int, createSubscriberFn func(ref *duckv1.KReference, ur
 				createSubscriberFn(channel_impl.AsRef(channels[i+1]), ""),
 			))
 		}
+
+		f.Setup("subscription is ready", subscription.IsReady(sub))
 	}
+
+	// attach the first channel to the source
+	f.Requirement("install containersource", containersource.Install(cs, containersource.WithSink(channel_impl.AsRef(channels[0]), "")))
 	f.Requirement("containersource goes ready", containersource.IsReady(cs))
 
 	f.Assert("chained channels relay events", assert.OnStore(sink).MatchEvent(test.HasType("dev.knative.eventing.samples.heartbeat")).AtLeast(1))


### PR DESCRIPTION
We want to reuse these features in serverless-operator repo in https://github.com/openshift-knative/serverless-operator/pull/2063 and there we use the latest version of reconciler-test which runs steps in parallel.
This PR picks some changes from [this earlier commit](https://github.com/openshift-knative/eventing/commit/466d123181f39f90a5f38583445910ffe61cbb0d) but only for tests which will be reused in serverless-operator. The whole commit can't be applied as the codebases difer.