### PR TITLE
[release-v1.10] less verbose logs on scheduler component  (#6912)

### DIFF
--- a/pkg/scheduler/statefulset/autoscaler.go
+++ b/pkg/scheduler/statefulset/autoscaler.go
@@ -167,7 +167,7 @@ func (a *autoscaler) doautoscale(ctx context.Context, attemptScaleDown bool, pen
 		return err
 	}
 
-	a.logger.Infow("checking adapter capacity",
+	a.logger.Debugw("checking adapter capacity",
 		zap.Int32("pending", pending),
 		zap.Int32("replicas", scale.Spec.Replicas),
 		zap.Int32("last ordinal", state.LastOrdinal))

--- a/pkg/scheduler/statefulset/scheduler.go
+++ b/pkg/scheduler/statefulset/scheduler.go
@@ -227,7 +227,7 @@ func (s *StatefulSetScheduler) Schedule(vpod scheduler.VPod) ([]duckv1alpha1.Pla
 
 func (s *StatefulSetScheduler) scheduleVPod(vpod scheduler.VPod) ([]duckv1alpha1.Placement, error) {
 	logger := s.logger.With("key", vpod.GetKey())
-	logger.Infow("scheduling", zap.Any("pending", toJSONable(s.pending)))
+	logger.Debugw("scheduling", zap.Any("pending", toJSONable(s.pending)))
 
 	// Get the current placements state
 	// Quite an expensive operation but safe and simple.
@@ -259,7 +259,7 @@ func (s *StatefulSetScheduler) scheduleVPod(vpod scheduler.VPod) ([]duckv1alpha1
 	// Exact number of vreplicas => do nothing
 	tr := scheduler.GetTotalVReplicas(placements)
 	if tr == vpod.GetVReplicas() {
-		logger.Info("scheduling succeeded (already scheduled)")
+		logger.Debug("scheduling succeeded (already scheduled)")
 		delete(s.pending, vpod.GetKey())
 
 		// Fully placed. Nothing to do
@@ -269,7 +269,7 @@ func (s *StatefulSetScheduler) scheduleVPod(vpod scheduler.VPod) ([]duckv1alpha1
 	if state.SchedulerPolicy != "" {
 		// Need less => scale down
 		if tr > vpod.GetVReplicas() {
-			logger.Infow("scaling down", zap.Int32("vreplicas", tr), zap.Int32("new vreplicas", vpod.GetVReplicas()))
+			logger.Debugw("scaling down", zap.Int32("vreplicas", tr), zap.Int32("new vreplicas", vpod.GetVReplicas()))
 
 			placements = s.removeReplicas(tr-vpod.GetVReplicas(), placements)
 
@@ -279,7 +279,7 @@ func (s *StatefulSetScheduler) scheduleVPod(vpod scheduler.VPod) ([]duckv1alpha1
 		}
 
 		// Need more => scale up
-		logger.Infow("scaling up", zap.Int32("vreplicas", tr), zap.Int32("new vreplicas", vpod.GetVReplicas()))
+		logger.Debugw("scaling up", zap.Int32("vreplicas", tr), zap.Int32("new vreplicas", vpod.GetVReplicas()))
 
 		placements, left = s.addReplicas(state, vpod.GetVReplicas()-tr, placements)
 


### PR DESCRIPTION
See #6912 on upstream