### PR TITLE
[release-v1.9] Update Dockerfiles with hack

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -15,5 +15,9 @@ RUN yum install -y kubectl httpd-tools
 
 RUN GOFLAGS='' go install github.com/mikefarah/yq/v3@latest
 
+# go install creates $GOPATH/.cache with root permissions, we delete it here
+# to avoid permission issues with the runtime users
+RUN rm -rf $GOPATH/.cache
+
 # Allow runtime users to add entries to /etc/passwd
 RUN chmod g+rw /etc/passwd

--- a/openshift/ci-operator/knative-images/apiserver_receive_adapter/Dockerfile
+++ b/openshift/ci-operator/knative-images/apiserver_receive_adapter/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r cmd/apiserver_receive_adapter/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-images/appender/Dockerfile
+++ b/openshift/ci-operator/knative-images/appender/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r cmd/appender/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-images/channel_controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/channel_controller/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r cmd/in_memory/channel_controller/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-images/channel_dispatcher/Dockerfile
+++ b/openshift/ci-operator/knative-images/channel_dispatcher/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r cmd/in_memory/channel_dispatcher/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-images/controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/controller/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r cmd/controller/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-images/event_display/Dockerfile
+++ b/openshift/ci-operator/knative-images/event_display/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r cmd/event_display/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-images/heartbeats/Dockerfile
+++ b/openshift/ci-operator/knative-images/heartbeats/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r cmd/heartbeats/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-images/heartbeats_receiver/Dockerfile
+++ b/openshift/ci-operator/knative-images/heartbeats_receiver/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r cmd/heartbeats_receiver/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-images/migrate/Dockerfile
+++ b/openshift/ci-operator/knative-images/migrate/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-images/mtbroker_filter/Dockerfile
+++ b/openshift/ci-operator/knative-images/mtbroker_filter/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r cmd/broker/filter/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-images/mtbroker_ingress/Dockerfile
+++ b/openshift/ci-operator/knative-images/mtbroker_ingress/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r cmd/broker/ingress/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-images/mtchannel_broker/Dockerfile
+++ b/openshift/ci-operator/knative-images/mtchannel_broker/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r cmd/mtchannel_broker/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-images/mtping/Dockerfile
+++ b/openshift/ci-operator/knative-images/mtping/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r cmd/mtping/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-images/pong/Dockerfile
+++ b/openshift/ci-operator/knative-images/pong/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r cmd/pong/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-images/schema/Dockerfile
+++ b/openshift/ci-operator/knative-images/schema/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r cmd/schema/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-images/webhook/Dockerfile
+++ b/openshift/ci-operator/knative-images/webhook/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r cmd/webhook/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-images/websocketsource/Dockerfile
+++ b/openshift/ci-operator/knative-images/websocketsource/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r cmd/websocketsource/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-test-images/event-flaker/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/event-flaker/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r test/test_images/event-flaker/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-test-images/event-library/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/event-library/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r test/test_images/event-library/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-test-images/event-sender/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/event-sender/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r test/test_images/event-sender/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-test-images/eventshub/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/eventshub/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r vendor/knative.dev/reconciler-test/cmd/eventshub/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-test-images/heartbeats/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/heartbeats/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r test/test_images/heartbeats/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-test-images/performance/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/performance/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r test/test_images/performance/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-test-images/print/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/print/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r test/test_images/print/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-test-images/recordevents/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/recordevents/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r test/test_images/recordevents/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-test-images/request-sender/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/request-sender/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r test/test_images/request-sender/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-test-images/wathola-fetcher/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/wathola-fetcher/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r test/test_images/wathola-fetcher/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-test-images/wathola-forwarder/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/wathola-forwarder/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r test/test_images/wathola-forwarder/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-test-images/wathola-receiver/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/wathola-receiver/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r test/test_images/wathola-receiver/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/openshift/ci-operator/knative-test-images/wathola-sender/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/wathola-sender/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r test/test_images/wathola-sender/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main


### PR DESCRIPTION
I basically ran `./openshift/generate.sh` on the repo, and it updated the files.

I expected to see only diffs for this PR:
* https://github.com/openshift-knative/hack/commit/58fa47118586118b2a7fa2f77b534c8ba5bf3568

But there is also the "cache removal":
* https://github.com/openshift-knative/hack/commit/03c35bdce85883be67c22eeaf96e98f141b300b9

So the images were a bit "outdated", or was my above execution not correct ? 