### PR TITLE
Remove waiting for test namespaces to be deleted after tests

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -116,9 +116,6 @@ function run_e2e_rekt_tests(){
   fi
   go_test_e2e ${RUN_FLAGS} ./test/rekt --images.producer.file="${images_file}" || failed=$?
 
-  # Wait for all test namespaces to be deleted.
-  timeout_non_zero 300 '[[ $(oc get project | grep -c test-) -gt 0 ]]' || return 1
-
   return $failed
 }
 


### PR DESCRIPTION
For two reasons:
* some tests might not use environment.Managed(t) so the test namespace won't be deleted after test
(for example, this test: https://github.com/knative/eventing/blob/main/test/rekt/apiserversource_test.go#L92)
* the REKT framework now doesn't delete a test namespace by default when the test fails, so when some tests fail this check would be timing out incorrectly
