### PR TITLE
Use HTTP POST when terminating istio proxy

### DIFF
--- a/cmd/heartbeats/main.go
+++ b/cmd/heartbeats/main.go
@@ -189,7 +189,10 @@ func main() {
 
 // maybeQuitIstioProxy shuts down Istio's proxy when available.
 func maybeQuitIstioProxy() {
-	_, err := http.DefaultClient.Get("http://localhost:15020/quitquitquit")
+	req, _ := http.NewRequest(http.MethodPost, "http://localhost:15020/quitquitquit", nil)
+
+	_, err := http.DefaultClient.Do(req)
+
 	if err != nil && !errors.Is(err, syscall.ECONNREFUSED) {
 		log.Println("[Ignore this warning if Istio proxy is not used on this pod]", err)
 	}

--- a/test/test_images/wathola-fetcher/main.go
+++ b/test/test_images/wathola-fetcher/main.go
@@ -31,7 +31,10 @@ func main() {
 }
 
 func maybeQuitIstioProxy() {
-	_, err := http.DefaultClient.Get("http://localhost:15020/quitquitquit")
+	req, _ := http.NewRequest(http.MethodPost, "http://localhost:15020/quitquitquit", nil)
+
+	_, err := http.DefaultClient.Do(req)
+
 	if err != nil && !errors.Is(err, syscall.ECONNREFUSED) {
 		log.Println("[Ignore this warning if Istio proxy is not used on this pod]", err)
 	}


### PR DESCRIPTION
Backport from upstream

HTTP GET doesn't work.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic -->

-
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed. -->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in https://github.com/knative/docs.
-->