### PR TITLE
[release-v1.9] Add eventshub service port name

### DIFF
--- a/openshift/generate.sh
+++ b/openshift/generate.sh
@@ -9,6 +9,7 @@ git apply "${repo_root_dir}/openshift/patches/005-k8s-min.patch"
 git apply "${repo_root_dir}/openshift/patches/018-rekt-test-override-kopublish.patch"
 git apply "${repo_root_dir}/openshift/patches/018-rekt-test-image-pod.patch"
 git apply "${repo_root_dir}/openshift/patches/020-mutemetrics.patch"
+git apply "${repo_root_dir}/openshift/patches/025-add-eventshub-port-name.patch"
 
 GO111MODULE=off go get -u github.com/openshift-knative/hack/cmd/generate
 

--- a/openshift/patches/025-add-eventshub-port-name.patch
+++ b/openshift/patches/025-add-eventshub-port-name.patch
@@ -1,0 +1,11 @@
+diff --git a/vendor/knative.dev/reconciler-test/pkg/eventshub/102-service.yaml b/vendor/knative.dev/reconciler-test/pkg/eventshub/102-service.yaml
+index c3d58ba09..b0400e7e9 100644
+--- a/vendor/knative.dev/reconciler-test/pkg/eventshub/102-service.yaml
++++ b/vendor/knative.dev/reconciler-test/pkg/eventshub/102-service.yaml
+@@ -22,5 +22,6 @@ spec:
+     app: eventshub-{{ .name }}
+   ports:
+     - protocol: TCP
++      name: http
+       port: 80
+       targetPort: 8080

--- a/vendor/knative.dev/reconciler-test/pkg/eventshub/102-service.yaml
+++ b/vendor/knative.dev/reconciler-test/pkg/eventshub/102-service.yaml
@@ -22,5 +22,6 @@ spec:
     app: eventshub-{{ .name }}
   ports:
     - protocol: TCP
+      name: http
       port: 80
       targetPort: 8080


### PR DESCRIPTION
Add patch for https://github.com/knative-sandbox/reconciler-test/commit/73fb8de7c2d0371fe7452b9371ce18121e8ed65e

For https://github.com/openshift-knative/serverless-operator/pull/2198