### PR TITLE
Subscription allows overriding namespace for Subscriber and Reply

### DIFF
--- a/test/rekt/resources/subscription/subscription.go
+++ b/test/rekt/resources/subscription/subscription.go
@@ -97,7 +97,9 @@ func WithReply(ref *duckv1.KReference, uri string) manifest.CfgFn {
 			sref := reply["ref"].(map[string]interface{})
 			sref["apiVersion"] = ref.APIVersion
 			sref["kind"] = ref.Kind
-			// skip namespace
+			if ref.Namespace != "" {
+				sref["namespace"] = ref.Namespace
+			}
 			sref["name"] = ref.Name
 		}
 	}

--- a/test/rekt/resources/subscription/subscription.yaml
+++ b/test/rekt/resources/subscription/subscription.yaml
@@ -29,7 +29,11 @@ spec:
     {{ if .subscriber.ref }}
     ref:
       kind: {{ .subscriber.ref.kind }}
+      {{ if .subscriber.ref.namespace }}
+      namespace: {{ .subscriber.ref.namespace }}
+      {{ else }}
       namespace: {{ .namespace }}
+      {{ end }}
       name: {{ .subscriber.ref.name }}
       apiVersion: {{ .subscriber.ref.apiVersion }}
     {{ end }}


### PR DESCRIPTION
This is a bug fix. Some parts were missed in the previous commit.