### PR TITLE
[release-v1.9] HTTP/2 disable patch from upstream

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -82,7 +82,7 @@ function install_serverless(){
   export KNATIVE_EVENTING_MANIFESTS_DIR
 
   local operator_dir=/tmp/serverless-operator
-  git clone --branch main https://github.com/openshift-knative/serverless-operator.git $operator_dir
+  git clone --branch release-1.30 https://github.com/openshift-knative/serverless-operator.git $operator_dir
   export GOPATH=/tmp/go
   local failed=0
   pushd $operator_dir || return $?

--- a/openshift/generate.sh
+++ b/openshift/generate.sh
@@ -6,6 +6,7 @@ repo_root_dir=$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..
 
 "${repo_root_dir}/hack/update-deps.sh" || exit 1
 git apply "${repo_root_dir}/openshift/patches/005-k8s-min.patch"
+git apply "${repo_root_dir}/openshift/patches/011-http2-cve.patch"
 git apply "${repo_root_dir}/openshift/patches/018-rekt-test-override-kopublish.patch"
 git apply "${repo_root_dir}/openshift/patches/018-rekt-test-image-pod.patch"
 git apply "${repo_root_dir}/openshift/patches/020-mutemetrics.patch"

--- a/openshift/patches/011-http2-cve.patch
+++ b/openshift/patches/011-http2-cve.patch
@@ -1,0 +1,44 @@
+diff --git a/vendor/knative.dev/pkg/webhook/webhook.go b/vendor/knative.dev/pkg/webhook/webhook.go
+index 435dfe38a..00fcd3c4a 100644
+--- a/vendor/knative.dev/pkg/webhook/webhook.go
++++ b/vendor/knative.dev/pkg/webhook/webhook.go
+@@ -63,6 +63,17 @@ type Options struct {
+ 	// GracePeriod is how long to wait after failing readiness probes
+ 	// before shutting down.
+ 	GracePeriod time.Duration
++
++	// EnableHTTP2 enables HTTP2 for webhooks.
++	// Mitigate CVE-2023-44487 by disabling HTTP2 by default until the Go
++	// standard library and golang.org/x/net are fully fixed.
++	// Right now, it is possible for authenticated and unauthenticated users to
++	// hold open HTTP2 connections and consume huge amounts of memory.
++	// See:
++	// * https://github.com/kubernetes/kubernetes/pull/121120
++	// * https://github.com/kubernetes/kubernetes/issues/121197
++	// * https://github.com/golang/go/issues/63417#issuecomment-1758858612
++	EnableHTTP2 bool
+ }
+ 
+ // Operation is the verb being operated on
+@@ -208,11 +219,18 @@ func (wh *Webhook) Run(stop <-chan struct{}) error {
+ 		QuietPeriod: wh.Options.GracePeriod,
+ 	}
+ 
++	// If TLSNextProto is not nil, HTTP/2 support is not enabled automatically.
++	nextProto := map[string]func(*http.Server, *tls.Conn, http.Handler){}
++	if wh.Options.EnableHTTP2 {
++		nextProto = nil
++	}
++
+ 	//nolint:gosec
+ 	server := &http.Server{
+-		Handler:   drainer,
+-		Addr:      fmt.Sprint(":", wh.Options.Port),
+-		TLSConfig: wh.tlsConfig,
++		Handler:      drainer,
++		Addr:         fmt.Sprint(":", wh.Options.Port),
++		TLSConfig:    wh.tlsConfig,
++		TLSNextProto: nextProto,
+ 	}
+ 
+ 	eg, ctx := errgroup.WithContext(ctx)

--- a/vendor/knative.dev/pkg/webhook/webhook.go
+++ b/vendor/knative.dev/pkg/webhook/webhook.go
@@ -63,6 +63,17 @@ type Options struct {
 	// GracePeriod is how long to wait after failing readiness probes
 	// before shutting down.
 	GracePeriod time.Duration
+
+	// EnableHTTP2 enables HTTP2 for webhooks.
+	// Mitigate CVE-2023-44487 by disabling HTTP2 by default until the Go
+	// standard library and golang.org/x/net are fully fixed.
+	// Right now, it is possible for authenticated and unauthenticated users to
+	// hold open HTTP2 connections and consume huge amounts of memory.
+	// See:
+	// * https://github.com/kubernetes/kubernetes/pull/121120
+	// * https://github.com/kubernetes/kubernetes/issues/121197
+	// * https://github.com/golang/go/issues/63417#issuecomment-1758858612
+	EnableHTTP2 bool
 }
 
 // Operation is the verb being operated on
@@ -208,11 +219,18 @@ func (wh *Webhook) Run(stop <-chan struct{}) error {
 		QuietPeriod: wh.Options.GracePeriod,
 	}
 
+	// If TLSNextProto is not nil, HTTP/2 support is not enabled automatically.
+	nextProto := map[string]func(*http.Server, *tls.Conn, http.Handler){}
+	if wh.Options.EnableHTTP2 {
+		nextProto = nil
+	}
+
 	//nolint:gosec
 	server := &http.Server{
-		Handler:   drainer,
-		Addr:      fmt.Sprint(":", wh.Options.Port),
-		TLSConfig: wh.tlsConfig,
+		Handler:      drainer,
+		Addr:         fmt.Sprint(":", wh.Options.Port),
+		TLSConfig:    wh.tlsConfig,
+		TLSNextProto: nextProto,
 	}
 
 	eg, ctx := errgroup.WithContext(ctx)


### PR DESCRIPTION
This patch cherry-picks https://github.com/knative/pkg/commit/b8c14ce9f90321c5a13ee5a41838a342343cc028 against 1.9 as a patch, and adds it to the "patch list"