### PR TITLE
[release-v1.11] Add encryption and auth tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ test-reconciler:
 	sh openshift/e2e-rekt-tests.sh
 .PHONY: test-reconciler
 
+test-encryption-auth-e2e:
+	sh openshift/e2e-encryption-auth-tests.sh
+.PHONY: test-encryption-auth-e2e
+
 # Target used by github actions.
 test-images:
 	for img in $(TEST_IMAGES); do \

--- a/openshift/e2e-encryption-auth-tests.sh
+++ b/openshift/e2e-encryption-auth-tests.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1090
+source "$(dirname "$0")/../vendor/knative.dev/hack/e2e-tests.sh"
+source "$(dirname "$0")/e2e-common.sh"
+
+set -Eeuox pipefail
+
+export TEST_IMAGE_TEMPLATE="${EVENTING_TEST_IMAGE_TEMPLATE}"
+
+env
+
+failed=0
+
+(( !failed )) && install_serverless || failed=1
+
+(( !failed )) && run_e2e_encryption_auth_tests || failed=1
+
+(( failed )) && dump_cluster_state
+
+(( failed )) && exit 1
+
+success
+

--- a/openshift/knative-eventing-encryption-auth.yaml
+++ b/openshift/knative-eventing-encryption-auth.yaml
@@ -1,0 +1,5 @@
+spec:
+  config:
+    config-features:
+      transport-encryption: "strict"
+      authentication.oidc: "enabled"


### PR DESCRIPTION
The Makefile command matches this regex https://github.com/openshift-knative/hack/blob/db9a2e68afe13fcf74b7e2883dfc9386742d7514/config/eventing.yaml#L41 so we will get a new job by running the Generate CI action

This is the current list of tests:
```
pierdipi@pierdipi eventing (release-v1.11) $ go test -list "(.*TLS.*|.*OIDC.*)" -tags=e2e ./test/rekt/...
?   	knative.dev/eventing/test/rekt/features	[no test files]
?   	knative.dev/eventing/test/rekt/features/apiserversource	[no test files]
?   	knative.dev/eventing/test/rekt/features/containersource	[no test files]
?   	knative.dev/eventing/test/rekt/features/featureflags	[no test files]
TestApiServerSourceDataPlaneTLS
TestMTChannelBrokerRotateTLSCertificates
TestInMemoryChannelRotateIngressTLSCertificate
TestContainerSourceWithTLS
TestPingSourceTLS
TestSinkBindingV1DeploymentTLS
TestTriggerTLSSubscriber
ok  	knative.dev/eventing/test/rekt	0.026s
ok  	knative.dev/eventing/test/rekt/features/broker	0.027s
ok  	knative.dev/eventing/test/rekt/features/channel	0.021s
?   	knative.dev/eventing/test/rekt/features/parallel	[no test files]
?   	knative.dev/eventing/test/rekt/features/pingsource	[no test files]
?   	knative.dev/eventing/test/rekt/features/sequence	[no test files]
?   	knative.dev/eventing/test/rekt/features/sinkbinding	[no test files]
?   	knative.dev/eventing/test/rekt/features/source	[no test files]
?   	knative.dev/eventing/test/rekt/features/trigger	[no test files]
?   	knative.dev/eventing/test/rekt/resources/addressable	[no test files]
ok  	knative.dev/eventing/test/rekt/features/knconf	0.025s
ok  	knative.dev/eventing/test/rekt/resources/account_role	0.040s
ok  	knative.dev/eventing/test/rekt/resources/apiserversource	0.016s
?   	knative.dev/eventing/test/rekt/resources/channel_template	[no test files]
?   	knative.dev/eventing/test/rekt/resources/eventtype	[no test files]
ok  	knative.dev/eventing/test/rekt/resources/broker	0.032s
ok  	knative.dev/eventing/test/rekt/resources/channel	0.024s
ok  	knative.dev/eventing/test/rekt/resources/channel_impl	0.024s
ok  	knative.dev/eventing/test/rekt/resources/containersource	0.039s
ok  	knative.dev/eventing/test/rekt/resources/delivery	0.041s
ok  	knative.dev/eventing/test/rekt/resources/namespace	0.024s
ok  	knative.dev/eventing/test/rekt/resources/parallel	0.023s
?   	knative.dev/eventing/test/rekt/resources/source	[no test files]
ok  	knative.dev/eventing/test/rekt/resources/pingsource	0.020s
ok  	knative.dev/eventing/test/rekt/resources/sequence	0.016s
ok  	knative.dev/eventing/test/rekt/resources/sinkbinding	0.016s
ok  	knative.dev/eventing/test/rekt/resources/subscription	0.016s
ok  	knative.dev/eventing/test/rekt/resources/trigger	0.015s
pierdipi@pierdipi eventing (release-v1.11) $ echo $?
0
```