### PR TITLE
Align names for mtbroker with upstream

### DIFF
--- a/openshift/generate.sh
+++ b/openshift/generate.sh
@@ -9,11 +9,3 @@ GO111MODULE=off go get -u github.com/openshift-knative/hack/cmd/generate
 $(go env GOPATH)/bin/generate \
   --root-dir "${repo_root_dir}" \
   --generators dockerfile
-
-images_dir="openshift/ci-operator/knative-images"
-
-# This allows having the final images with the expected names
-rm -rf "${repo_root_dir}/${images_dir}/mtbroker_filter"
-rm -rf "${repo_root_dir}/${images_dir}/mtbroker_ingress"
-mv "${repo_root_dir}/${images_dir}/filter" "${repo_root_dir}/${images_dir}/mtbroker_filter"
-mv "${repo_root_dir}/${images_dir}/ingress" "${repo_root_dir}/${images_dir}/mtbroker_ingress"


### PR DESCRIPTION
* The folder with Dockerfile will be named "filter" instead of "mtbroker_filter" and "ingress" instead of "mtbroker_ingress". * The CI image will be published at
registry.ci.openshift.org/openshift/knative-eventing-filter and registry.ci.openshift.org/openshift/knative-eventing-ingress (right now it's published under
registry.ci.openshift.org/openshift/knative-eventing-mtbroker-filter so our images.yaml references non-existent images)
* The generated CI config will have the correct env variable once the CI config is re-generated:
```- env: KNATIVE_EVENTING_FILTER
     name: knative-eventing-filter
```
* In the end, the image will be properly replaced in CI with currently built image because we run "make generate-release" once again.