### PR TITLE
Increase Ready timeout for TestChannelConformance to 4 minutes

### DIFF
--- a/test/rekt/channel_test.go
+++ b/test/rekt/channel_test.go
@@ -47,6 +47,7 @@ func TestChannelConformance(t *testing.T) {
 		knative.WithTracingConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
+		environment.WithPollTimings(5*time.Second, 4*time.Minute),
 	)
 
 	channelName := "mychannelimpl"


### PR DESCRIPTION
The default 2-minute timeout might not be enough in some scenarios where deploying takes longer (like with Istio).