### PR TITLE
skipping make command  for P/Z.

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -104,7 +104,6 @@ function run_e2e_rekt_tests(){
   if [ $HW_ARCH != "ppc64le" ] && [ $HW_ARCH != "s390x" ]; then
     make generate-release
   fi
-  make generate-release
   cat "${images_file}"
 
   local test_name="${1:-}"

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -97,8 +97,13 @@ function install_serverless(){
 
 function run_e2e_rekt_tests(){
   header "Running E2E Reconciler Tests"
+  HW_ARCH=$(arch)
   
   images_file=$(dirname $(realpath "$0"))/images.yaml
+  #skipping for P/Z as the test images aren't multiarch.
+  if [ $HW_ARCH != "ppc64le" ] && [ $HW_ARCH != "s390x" ]; then
+    make generate-release
+  fi
   make generate-release
   cat "${images_file}"
 


### PR DESCRIPTION
Skipping `make generate-release` command for P/Z as the generate images in the image.yaml aren't multi-arch. We have a sed command for the images.yaml in the downstream code but this `make generate-release` overwrites the images.yaml file.