### PR TITLE
Upgrade tests account for last event being interrupted (#7447)

### DIFF
--- a/test/upgrade/prober/wathola/event/services.go
+++ b/test/upgrade/prober/wathola/event/services.go
@@ -108,7 +108,11 @@ func (f *finishedStore) RegisterFinished(finished *Finished) {
 	log.Infof("waiting additional %v to be sure all events came", d)
 	time.Sleep(d)
 	receivedEvents := f.steps.Count()
-	if receivedEvents != finished.EventsSent {
+
+	if receivedEvents != finished.EventsSent &&
+		// If sending was interrupted, tolerate one more received
+		// event as there's no way to check if the last event is delivered or not.
+		!(finished.SendingInterrupted && receivedEvents == finished.EventsSent+1) {
 		f.errors.throwUnexpected("expecting to have %v unique events received, "+
 			"but received %v unique events", finished.EventsSent, receivedEvents)
 		f.reportViolations(finished)

--- a/test/upgrade/prober/wathola/event/types.go
+++ b/test/upgrade/prober/wathola/event/types.go
@@ -46,6 +46,7 @@ type Finished struct {
 	EventsSent         int
 	TotalRequests      int
 	UnavailablePeriods []UnavailablePeriod
+	SendingInterrupted bool
 }
 
 // Type returns a type of a event


### PR DESCRIPTION
Backport from upstream.

* Fix reporting index of the failed step

The warning had a wrong index:
{"level":"info","ts":"2023-11-13T14:00:03.816770975Z","caller":"sender/services.go:207","msg":"Sending step event #16691 to
\"http://sut-kn-channel.eventing-e2e0.svc.cluster.local\""} {"level":"warn","ts":"2023-11-13T14:00:03.821102525Z","caller":"sender/services.go:102","msg":"Could not send step event 16690, retrying (1): Post
\"http://sut-kn-channel.eventing-e2e0.svc.cluster.local\": dial tcp 172.30.99.91:80: connect: connection refused"}

* Upgrade tests account for last event being interrupted