### PR TITLE
CM Bundle injection for api server source 

### DIFF
--- a/pkg/reconciler/apiserversource/resources/cabundle_configmap.go
+++ b/pkg/reconciler/apiserversource/resources/cabundle_configmap.go
@@ -1,0 +1,31 @@
+package resources
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/kmeta"
+)
+
+const (
+	// user-provided and system CA certificates
+	TrustedCAConfigMapName   = "config-openshift-trusted-cabundle"
+	TrustedCAConfigMapVolume = TrustedCAConfigMapName + "-volume"
+	TrustedCAKey             = "ca-bundle.crt"
+)
+
+func MakeTrustedCABundleConfigMap(args *ReceiveAdapterArgs) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      TrustedCAConfigMapName,
+			Namespace: args.Source.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "knative-eventing",
+				// user-provided and system CA certificates
+				"config.openshift.io/inject-trusted-cabundle": "true",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				*kmeta.NewControllerRef(args.Source),
+			},
+		},
+	}
+}

--- a/pkg/reconciler/apiserversource/resources/receive_adapter.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter.go
@@ -38,6 +38,10 @@ import (
 	reconcilersource "knative.dev/eventing/pkg/reconciler/source"
 )
 
+const (
+	OcpTrusedCaBundleMountPath = "/ocp-serverless-custom-certs"
+)
+
 // ReceiveAdapterArgs are the arguments needed to create a ApiServer Receive Adapter.
 // Every field is required.
 type ReceiveAdapterArgs struct {
@@ -85,6 +89,22 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) (*appsv1.Deployment, error) {
 				Spec: corev1.PodSpec{
 					ServiceAccountName: args.Source.Spec.ServiceAccountName,
 					EnableServiceLinks: ptr.Bool(false),
+					Volumes: []corev1.Volume{
+						{
+							Name: TrustedCAConfigMapVolume,
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: TrustedCAConfigMapName},
+									Items: []corev1.KeyToPath{
+										{
+											Key:  TrustedCAKey,
+											Path: TrustedCAKey,
+										},
+									},
+								},
+							},
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							Name:  "receive-adapter",
@@ -109,6 +129,13 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) (*appsv1.Deployment, error) {
 								ReadOnlyRootFilesystem:   ptr.Bool(true),
 								RunAsNonRoot:             ptr.Bool(true),
 								Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      TrustedCAConfigMapVolume,
+									MountPath: OcpTrusedCaBundleMountPath,
+									ReadOnly:  true,
+								},
 							},
 						},
 					},

--- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
@@ -135,6 +135,22 @@ O2dgzikq8iSy1BlRsVw=
 				Spec: corev1.PodSpec{
 					ServiceAccountName: "source-svc-acct",
 					EnableServiceLinks: ptr.Bool(false),
+					Volumes: []corev1.Volume{
+						{
+							Name: TrustedCAConfigMapVolume,
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: TrustedCAConfigMapName},
+									Items: []corev1.KeyToPath{
+										{
+											Key:  TrustedCAKey,
+											Path: TrustedCAKey,
+										},
+									},
+								},
+							},
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							Name:  "receive-adapter",
@@ -195,6 +211,13 @@ O2dgzikq8iSy1BlRsVw=
 								ReadOnlyRootFilesystem:   ptr.Bool(true),
 								RunAsNonRoot:             ptr.Bool(true),
 								Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      TrustedCAConfigMapVolume,
+									MountPath: OcpTrusedCaBundleMountPath,
+									ReadOnly:  true,
+								},
 							},
 						},
 					},


### PR DESCRIPTION
On clean deployment of `ApiServerSource`, we now create the Openshift CA trust bundle CM, and mount it on the deployment 