### PR TITLE
fix: remove the incorrect test case from 1.11

### DIFF
--- a/pkg/apis/feature/features_test.go
+++ b/pkg/apis/feature/features_test.go
@@ -67,7 +67,4 @@ func TestShouldNotOverrideDefaults(t *testing.T) {
 	if !f.IsDisabled(KReferenceGroup) && !f.IsEnabled(KReferenceGroup) {
 		t.Errorf("Expected default value for %s in flags %+v", KReferenceGroup, f)
 	}
-	if !f.IsEnabled(NewTriggerFilters) {
-		t.Errorf("Expected default value for %s to be %s in flags %+v", NewTriggerFilters, Enabled, f)
-	}
 }


### PR DESCRIPTION
When backporting https://github.com/knative/eventing/pull/7385, the assertion that new trigger filters are enabled accidentally got included onto `release-v1.11`, even though it is not enabled by default on `release-v1.11`. This PR removes that check

/cc @matzew 