### PR TITLE
[main] Backporting the CM patch to release-next ocp/main

### DIFF
--- a/openshift/patches/023-configmap-trusted-cabundle.patch
+++ b/openshift/patches/023-configmap-trusted-cabundle.patch
@@ -1,0 +1,30 @@
+diff --git a/config/openshift-trusted-cabundle.yaml b/config/openshift-trusted-cabundle.yaml
+new file mode 100644
+index 000000000..a4c1a5f73
+--- /dev/null
++++ b/config/openshift-trusted-cabundle.yaml
+@@ -0,0 +1,23 @@
++# Copyright 2020 The Knative Authors
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     https://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++apiVersion: v1
++kind: ConfigMap
++metadata:
++  name: config-openshift-trusted-cabundle
++  namespace: knative-eventing
++  labels:
++    app.kubernetes.io/version: devel
++    app.kubernetes.io/name: knative-eventing
++    config.openshift.io/inject-trusted-cabundle: "true"
+-- 


### PR DESCRIPTION
Original fix (patch and apply) was here: https://github.com/openshift-knative/eventing/pull/437)