### PR TITLE
Backporting the 'ApiServerSource CM create and mount' patch to release-next (main)

### DIFF
--- a/openshift/patches/023-configmap-trusted-cabundle_apiserver_source.patch
+++ b/openshift/patches/023-configmap-trusted-cabundle_apiserver_source.patch
@@ -1,0 +1,171 @@
+diff --git a/pkg/reconciler/apiserversource/apiserversource.go b/pkg/reconciler/apiserversource/apiserversource.go
+index f96a8e4c9..ed1ff2fe9 100644
+--- a/pkg/reconciler/apiserversource/apiserversource.go
++++ b/pkg/reconciler/apiserversource/apiserversource.go
+@@ -215,6 +215,12 @@ func (r *Reconciler) createReceiveAdapter(ctx context.Context, src *v1.ApiServer
+ 		msg := "Deployment created"
+ 		if err != nil {
+ 			msg = fmt.Sprint("Deployment created, error:", err)
++		} else {
++			// make CM only on clean creation
++			err := r.ensureCaTrustBundleConfigMap(ctx, src, adapterArgs)
++			if err != nil {
++				return nil, err
++			}
+ 		}
+ 		controller.GetEventRecorder(ctx).Eventf(src, corev1.EventTypeNormal, apiserversourceDeploymentCreated, "%s", msg)
+ 		return ra, err
+@@ -235,6 +241,20 @@ func (r *Reconciler) createReceiveAdapter(ctx context.Context, src *v1.ApiServer
+ 	return ra, nil
+ }
+ 
++func (r *Reconciler) ensureCaTrustBundleConfigMap(ctx context.Context, src *v1.ApiServerSource, adapterArgs resources.ReceiveAdapterArgs) error {
++	_, err := r.kubeClientSet.CoreV1().ConfigMaps(src.Namespace).Get(ctx, resources.TrustedCAConfigMapName, metav1.GetOptions{})
++	if apierrors.IsNotFound(err) {
++		trustedBundleCM := resources.MakeTrustedCABundleConfigMap(&adapterArgs)
++
++		_, err := r.kubeClientSet.CoreV1().ConfigMaps(src.Namespace).Create(ctx, trustedBundleCM, metav1.CreateOptions{})
++		if err != nil && !apierrors.IsAlreadyExists(err) {
++			return fmt.Errorf("error creating trusted CA bundle configmap: %v", err)
++		}
++	}
++
++	return nil
++}
++
+ func (r *Reconciler) podSpecChanged(oldPodSpec corev1.PodSpec, newPodSpec corev1.PodSpec) bool {
+ 	if !equality.Semantic.DeepDerivative(newPodSpec, oldPodSpec) {
+ 		return true
+diff --git a/pkg/reconciler/apiserversource/resources/cabundle_configmap.go b/pkg/reconciler/apiserversource/resources/cabundle_configmap.go
+new file mode 100644
+index 000000000..5091d3d39
+--- /dev/null
++++ b/pkg/reconciler/apiserversource/resources/cabundle_configmap.go
+@@ -0,0 +1,31 @@
++package resources
++
++import (
++	corev1 "k8s.io/api/core/v1"
++	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
++	"knative.dev/pkg/kmeta"
++)
++
++const (
++	// user-provided and system CA certificates
++	TrustedCAConfigMapName   = "config-openshift-trusted-cabundle"
++	TrustedCAConfigMapVolume = TrustedCAConfigMapName + "-volume"
++	TrustedCAKey             = "ca-bundle.crt"
++)
++
++func MakeTrustedCABundleConfigMap(args *ReceiveAdapterArgs) *corev1.ConfigMap {
++	return &corev1.ConfigMap{
++		ObjectMeta: metav1.ObjectMeta{
++			Name:      TrustedCAConfigMapName,
++			Namespace: args.Source.Namespace,
++			Labels: map[string]string{
++				"app.kubernetes.io/name": "knative-eventing",
++				// user-provided and system CA certificates
++				"config.openshift.io/inject-trusted-cabundle": "true",
++			},
++			OwnerReferences: []metav1.OwnerReference{
++				*kmeta.NewControllerRef(args.Source),
++			},
++		},
++	}
++}
+diff --git a/pkg/reconciler/apiserversource/resources/receive_adapter.go b/pkg/reconciler/apiserversource/resources/receive_adapter.go
+index 48ee41eb1..61ab4fbb2 100644
+--- a/pkg/reconciler/apiserversource/resources/receive_adapter.go
++++ b/pkg/reconciler/apiserversource/resources/receive_adapter.go
+@@ -38,6 +38,10 @@ import (
+ 	reconcilersource "knative.dev/eventing/pkg/reconciler/source"
+ )
+ 
++const (
++	OcpTrusedCaBundleMountPath = "/ocp-serverless-custom-certs"
++)
++
+ // ReceiveAdapterArgs are the arguments needed to create a ApiServer Receive Adapter.
+ // Every field is required.
+ type ReceiveAdapterArgs struct {
+@@ -85,6 +89,22 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) (*appsv1.Deployment, error) {
+ 				Spec: corev1.PodSpec{
+ 					ServiceAccountName: args.Source.Spec.ServiceAccountName,
+ 					EnableServiceLinks: ptr.Bool(false),
++					Volumes: []corev1.Volume{
++						{
++							Name: TrustedCAConfigMapVolume,
++							VolumeSource: corev1.VolumeSource{
++								ConfigMap: &corev1.ConfigMapVolumeSource{
++									LocalObjectReference: corev1.LocalObjectReference{Name: TrustedCAConfigMapName},
++									Items: []corev1.KeyToPath{
++										{
++											Key:  TrustedCAKey,
++											Path: TrustedCAKey,
++										},
++									},
++								},
++							},
++						},
++					},
+ 					Containers: []corev1.Container{
+ 						{
+ 							Name:  "receive-adapter",
+@@ -110,6 +130,13 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) (*appsv1.Deployment, error) {
+ 								RunAsNonRoot:             ptr.Bool(true),
+ 								Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+ 							},
++							VolumeMounts: []corev1.VolumeMount{
++								{
++									Name:      TrustedCAConfigMapVolume,
++									MountPath: OcpTrusedCaBundleMountPath,
++									ReadOnly:  true,
++								},
++							},
+ 						},
+ 					},
+ 				},
+diff --git a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+index 424d747e7..9de5c4a79 100644
+--- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
++++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+@@ -135,6 +135,22 @@ O2dgzikq8iSy1BlRsVw=
+ 				Spec: corev1.PodSpec{
+ 					ServiceAccountName: "source-svc-acct",
+ 					EnableServiceLinks: ptr.Bool(false),
++					Volumes: []corev1.Volume{
++						{
++							Name: TrustedCAConfigMapVolume,
++							VolumeSource: corev1.VolumeSource{
++								ConfigMap: &corev1.ConfigMapVolumeSource{
++									LocalObjectReference: corev1.LocalObjectReference{Name: TrustedCAConfigMapName},
++									Items: []corev1.KeyToPath{
++										{
++											Key:  TrustedCAKey,
++											Path: TrustedCAKey,
++										},
++									},
++								},
++							},
++						},
++					},
+ 					Containers: []corev1.Container{
+ 						{
+ 							Name:  "receive-adapter",
+@@ -196,6 +212,13 @@ O2dgzikq8iSy1BlRsVw=
+ 								RunAsNonRoot:             ptr.Bool(true),
+ 								Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+ 							},
++							VolumeMounts: []corev1.VolumeMount{
++								{
++									Name:      TrustedCAConfigMapVolume,
++									MountPath: OcpTrusedCaBundleMountPath,
++									ReadOnly:  true,
++								},
++							},
+ 						},
+ 					},
+ 				},
+-- 
+2.43.0
+


### PR DESCRIPTION
Original fix (patch and apply) was here: https://github.com/openshift-knative/eventing/pull/441