### PR TITLE
Use correct OWNER_ALIASES when cutting release branch

### DIFF
--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -17,7 +17,7 @@ git commit -sm ":fire: remove unneeded workflows" .github/
 
 # Copy the openshift extra files from the OPENSHIFT/main branch.
 git fetch openshift main
-git checkout openshift/main -- .github/workflows openshift OWNERS Makefile
+git checkout openshift/main -- .github/workflows openshift OWNERS OWNERS_ALIASES Makefile
 
 git apply openshift/patches/*
 


### PR DESCRIPTION
Somehow we are not using the correct owner_aliases files when we cut the release branch