### PR TITLE
Align mounth path for OCP cert inject towards the other workloads in Serverless Operator 1.32

### DIFF
--- a/pkg/reconciler/apiserversource/resources/receive_adapter.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter.go
@@ -39,7 +39,7 @@ import (
 )
 
 const (
-	OcpTrusedCaBundleMountPath = "/ocp-serverless-custom-certs"
+	OcpTrusedCaBundleMountPath = "/ocp-serverless-custom-certs/" + TrustedCAKey
 )
 
 // ReceiveAdapterArgs are the arguments needed to create a ApiServer Receive Adapter.
@@ -134,6 +134,7 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) (*appsv1.Deployment, error) {
 								{
 									Name:      TrustedCAConfigMapVolume,
 									MountPath: OcpTrusedCaBundleMountPath,
+									SubPath:   TrustedCAKey,
 									ReadOnly:  true,
 								},
 							},

--- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
@@ -216,6 +216,7 @@ O2dgzikq8iSy1BlRsVw=
 								{
 									Name:      TrustedCAConfigMapVolume,
 									MountPath: OcpTrusedCaBundleMountPath,
+									SubPath:   TrustedCAKey,
 									ReadOnly:  true,
 								},
 							},


### PR DESCRIPTION
Basically adjusting to the logic from here: https://github.com/openshift-knative/serverless-operator/pull/2422