### PR TITLE
Backport EventType auto-create tests for Broker and Channel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,10 @@ test-encryption-auth-e2e:
 	sh openshift/e2e-encryption-auth-tests.sh
 .PHONY: test-encryption-auth-e2e
 
+test-experimental:
+	sh openshift/e2e-experimental-tests.sh
+.PHONY: test-experimental
+
 # Target used by github actions.
 test-images:
 	for img in $(TEST_IMAGES); do \

--- a/config/core/resources/eventtype.yaml
+++ b/config/core/resources/eventtype.yaml
@@ -31,7 +31,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
-        description: 'EventType represents a type of event that can be consumed from a Broker.'
+        description: 'EventType represents a type of event that can be consumed from a resource.'
         properties:
           spec:
             description: 'Spec defines the desired state of the EventType.'
@@ -40,7 +40,7 @@ spec:
               broker:
                 type: string
               reference:
-                description: Reference Broker. For example
+                description: Reference a resource. For example, Broker.
                 type: object
                 properties:
                   apiVersion:

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -280,3 +280,27 @@ function wait_until_object_exists() {
   kubectl ${KUBECTL_ARGS}
   return 1
 }
+
+function run_e2e_rekt_experimental_tests(){
+  header "Running E2E experimental Tests"
+
+  oc patch knativeeventing --type merge -n "${EVENTING_NAMESPACE}" knative-eventing --patch-file "${SCRIPT_DIR}/knative-eventing-experimental.yaml"
+
+  images_file=$(dirname $(realpath "$0"))/images.yaml
+  make generate-release
+  cat "${images_file}"
+
+  oc wait --for=condition=Ready knativeeventing.operator.knative.dev knative-eventing -n "${EVENTING_NAMESPACE}" --timeout=900s
+
+  local failed=0
+
+  # check for test flags
+  RUN_FLAGS="-timeout=1h -parallel=20"
+  if [ -n "${EVENTING_TEST_FLAGS:-}" ]; then
+    RUN_FLAGS="${EVENTING_TEST_FLAGS}"
+  fi
+
+  go_test_e2e ${RUN_FLAGS} ./test/experimental --images.producer.file="${images_file}" || failed=$?
+
+  return $failed
+}

--- a/openshift/e2e-experimental-tests.sh
+++ b/openshift/e2e-experimental-tests.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1090
+source "$(dirname "$0")/../vendor/knative.dev/hack/e2e-tests.sh"
+source "$(dirname "$0")/e2e-common.sh"
+
+set -Eeuox pipefail
+
+export TEST_IMAGE_TEMPLATE="${EVENTING_TEST_IMAGE_TEMPLATE}"
+
+env
+
+failed=0
+
+(( !failed )) && install_serverless || failed=1
+
+(( !failed )) && run_e2e_rekt_experimental_tests || failed=1
+
+(( failed )) && dump_cluster_state
+
+(( failed )) && exit 1
+
+success
+

--- a/openshift/knative-eventing-experimental.yaml
+++ b/openshift/knative-eventing-experimental.yaml
@@ -1,0 +1,8 @@
+spec:
+  config:
+    config-features:
+      kreference-group: "enabled"
+      delivery-retryafter: "enabled"
+      delivery-timeout: "enabled"
+      new-trigger-filters: "enabled"
+      eventtype-auto-create: "enabled"

--- a/test/experimental/config/features.yaml
+++ b/test/experimental/config/features.yaml
@@ -25,3 +25,4 @@ data:
   delivery-retryafter: "enabled"
   delivery-timeout: "enabled"
   new-trigger-filters: "enabled"
+  eventtype-auto-create: "enabled"

--- a/test/experimental/eventtype_autocreate_test.go
+++ b/test/experimental/eventtype_autocreate_test.go
@@ -1,0 +1,42 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2023 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package experimental
+
+import (
+	"testing"
+
+	"knative.dev/eventing/test/experimental/features/eventtype_autocreate"
+
+	"knative.dev/pkg/system"
+	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/k8s"
+	"knative.dev/reconciler-test/pkg/knative"
+)
+
+func TestIMCEventTypeAutoCreate(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	env.Test(ctx, t, eventtype_autocreate.AutoCreateEventTypesOnIMC())
+}

--- a/test/experimental/eventtype_autocreate_test.go
+++ b/test/experimental/eventtype_autocreate_test.go
@@ -23,6 +23,7 @@ import (
 
 	"knative.dev/pkg/system"
 	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/knative"
 )
@@ -39,6 +40,22 @@ func TestIMCEventTypeAutoCreate(t *testing.T) {
 	)
 
 	env.Test(ctx, t, eventtype_autocreate.AutoCreateEventTypesOnIMC())
+}
+
+func TestBrokerEventTypeAutoCreate(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+	brokerName := feature.MakeRandomK8sName("broker")
+
+	env.Prerequisite(ctx, t, InstallMTBroker(brokerName))
+	env.Test(ctx, t, eventtype_autocreate.AutoCreateEventTypesOnBroker(brokerName))
 }
 
 func TestPingSourceEventTypeMatch(t *testing.T) {

--- a/test/experimental/eventtype_autocreate_test.go
+++ b/test/experimental/eventtype_autocreate_test.go
@@ -40,3 +40,17 @@ func TestIMCEventTypeAutoCreate(t *testing.T) {
 
 	env.Test(ctx, t, eventtype_autocreate.AutoCreateEventTypesOnIMC())
 }
+
+func TestPingSourceEventTypeMatch(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	env.Test(ctx, t, eventtype_autocreate.AutoCreateEventTypeEventsFromPingSource())
+}

--- a/test/experimental/eventtype_autocreate_test.go
+++ b/test/experimental/eventtype_autocreate_test.go
@@ -57,17 +57,3 @@ func TestBrokerEventTypeAutoCreate(t *testing.T) {
 	env.Prerequisite(ctx, t, InstallMTBroker(brokerName))
 	env.Test(ctx, t, eventtype_autocreate.AutoCreateEventTypesOnBroker(brokerName))
 }
-
-func TestPingSourceEventTypeMatch(t *testing.T) {
-	t.Parallel()
-
-	ctx, env := global.Environment(
-		knative.WithKnativeNamespace(system.Namespace()),
-		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
-		k8s.WithEventListener,
-		environment.Managed(t),
-	)
-
-	env.Test(ctx, t, eventtype_autocreate.AutoCreateEventTypeEventsFromPingSource())
-}

--- a/test/experimental/features/eventtype_autocreate/features.go
+++ b/test/experimental/features/eventtype_autocreate/features.go
@@ -30,6 +30,7 @@ import (
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/eventshub/assert"
 	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/manifest"
 	"knative.dev/reconciler-test/pkg/resources/service"
 )
@@ -38,7 +39,7 @@ func AutoCreateEventTypesOnIMC() *feature.Feature {
 	f := feature.NewFeature()
 
 	event := cetest.FullEvent()
-	event.SetType("test.custom.event.type")
+	event.SetType("test.imc.custom.event.type")
 
 	sender := feature.MakeRandomK8sName("sender")
 	sub := feature.MakeRandomK8sName("subscription")
@@ -63,6 +64,36 @@ func AutoCreateEventTypesOnIMC() *feature.Feature {
 	expectedTypes := sets.New(event.Type())
 
 	f.Alpha("imc").
+		Must("deliver events to subscriber", assert.OnStore(sink).MatchEvent(cetest.HasId(event.ID())).AtLeast(1)).
+		Must("create event type", eventtype.WaitForEventType(eventtype.AssertPresent(expectedTypes)))
+
+	return f
+}
+
+func AutoCreateEventTypesOnBroker(brokerName string) *feature.Feature {
+	f := feature.NewFeature()
+
+	event := cetest.FullEvent()
+	event.SetType("test.broker.custom.event.type")
+
+	sender := feature.MakeRandomK8sName("sender")
+	triggerName := feature.MakeRandomK8sName("trigger")
+	sink := feature.MakeRandomK8sName("sink")
+
+	f.Setup("install sink", eventshub.Install(sink, eventshub.StartReceiver))
+	f.Setup("install subscription", trigger.Install(triggerName, brokerName, trigger.WithSubscriber(service.AsKReference(sink), "")))
+
+	f.Setup("trigger is ready", trigger.IsReady(triggerName))
+	f.Setup("broker is addressable", k8s.IsAddressable(broker.GVR(), brokerName))
+
+	f.Requirement("install event sender", eventshub.Install(sender,
+		eventshub.StartSenderToResource(broker.GVR(), brokerName),
+		eventshub.InputEvent(event),
+	))
+
+	expectedTypes := sets.New(event.Type())
+
+	f.Alpha("broker").
 		Must("deliver events to subscriber", assert.OnStore(sink).MatchEvent(cetest.HasId(event.ID())).AtLeast(1)).
 		Must("create event type", eventtype.WaitForEventType(eventtype.AssertPresent(expectedTypes)))
 

--- a/test/experimental/features/eventtype_autocreate/features.go
+++ b/test/experimental/features/eventtype_autocreate/features.go
@@ -95,7 +95,7 @@ func AutoCreateEventTypesOnBroker(brokerName string) *feature.Feature {
 
 	f.Alpha("broker").
 		Must("deliver events to subscriber", assert.OnStore(sink).MatchEvent(cetest.HasId(event.ID())).AtLeast(1)).
-		Must("create event type", eventtype.WaitForEventType(eventtype.AssertPresent(expectedTypes)))
+		Must("create event type", eventtype.WaitForEventType(eventtype.AssertExactPresent(expectedTypes)))
 
 	return f
 }

--- a/test/experimental/features/eventtype_autocreate/features.go
+++ b/test/experimental/features/eventtype_autocreate/features.go
@@ -14,14 +14,23 @@ limitations under the License.
 package eventtype_autocreate
 
 import (
+	"context"
+
+	"github.com/cloudevents/sdk-go/v2/test"
 	cetest "github.com/cloudevents/sdk-go/v2/test"
 	"k8s.io/apimachinery/pkg/util/sets"
+	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
+	"knative.dev/eventing/test/rekt/resources/broker"
 	"knative.dev/eventing/test/rekt/resources/channel_impl"
 	"knative.dev/eventing/test/rekt/resources/eventtype"
+	"knative.dev/eventing/test/rekt/resources/pingsource"
 	"knative.dev/eventing/test/rekt/resources/subscription"
+	"knative.dev/eventing/test/rekt/resources/trigger"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/eventshub/assert"
 	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/manifest"
 	"knative.dev/reconciler-test/pkg/resources/service"
 )
 
@@ -56,6 +65,46 @@ func AutoCreateEventTypesOnIMC() *feature.Feature {
 	f.Alpha("imc").
 		Must("deliver events to subscriber", assert.OnStore(sink).MatchEvent(cetest.HasId(event.ID())).AtLeast(1)).
 		Must("create event type", eventtype.WaitForEventType(eventtype.AssertPresent(expectedTypes)))
+
+	return f
+}
+
+func AutoCreateEventTypeEventsFromPingSource() *feature.Feature {
+	source := feature.MakeRandomK8sName("source")
+	sink := feature.MakeRandomK8sName("sink")
+	via := feature.MakeRandomK8sName("via")
+
+	f := new(feature.Feature)
+
+	//Install the broker
+	brokerName := feature.MakeRandomK8sName("broker")
+	f.Setup("install broker", broker.Install(brokerName, broker.WithEnvConfig()...))
+	f.Setup("broker is ready", broker.IsReady(brokerName))
+	f.Setup("broker is addressable", broker.IsAddressable(brokerName))
+	f.Setup("install sink", eventshub.Install(sink, eventshub.StartReceiver))
+	f.Setup("install trigger", trigger.Install(via, brokerName, trigger.WithSubscriber(service.AsKReference(sink), "")))
+	f.Setup("trigger goes ready", trigger.IsReady(via))
+
+	f.Requirement("install pingsource", func(ctx context.Context, t feature.T) {
+		brokeruri, err := broker.Address(ctx, brokerName)
+		if err != nil {
+			t.Error("failed to get address of broker", err)
+		}
+		cfg := []manifest.CfgFn{
+			pingsource.WithSink(&duckv1.Destination{URI: brokeruri.URL, CACerts: brokeruri.CACerts}),
+			pingsource.WithData("text/plain", "hello, world!"),
+		}
+		pingsource.Install(source, cfg...)(ctx, t)
+	})
+	f.Requirement("PingSource goes ready", pingsource.IsReady(source))
+
+	expectedCeTypes := sets.New(sourcesv1.PingSourceEventType)
+
+	f.Stable("pingsource as event source").
+		Must("delivers events on broker with URI", assert.OnStore(sink).MatchEvent(
+			test.HasType(sourcesv1.PingSourceEventType)).AtLeast(1)).
+		Must("PingSource test eventtypes match", eventtype.WaitForEventType(
+			eventtype.AssertPresent(expectedCeTypes)))
 
 	return f
 }

--- a/test/experimental/features/eventtype_autocreate/features.go
+++ b/test/experimental/features/eventtype_autocreate/features.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2023 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eventtype_autocreate
+
+import (
+	cetest "github.com/cloudevents/sdk-go/v2/test"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"knative.dev/eventing/test/rekt/resources/channel_impl"
+	"knative.dev/eventing/test/rekt/resources/eventtype"
+	"knative.dev/eventing/test/rekt/resources/subscription"
+	"knative.dev/reconciler-test/pkg/eventshub"
+	"knative.dev/reconciler-test/pkg/eventshub/assert"
+	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/resources/service"
+)
+
+func AutoCreateEventTypesOnIMC() *feature.Feature {
+	f := feature.NewFeature()
+
+	event := cetest.FullEvent()
+	event.SetType("test.custom.event.type")
+
+	sender := feature.MakeRandomK8sName("sender")
+	sub := feature.MakeRandomK8sName("subscription")
+	channelName := feature.MakeRandomK8sName("channel")
+	sink := feature.MakeRandomK8sName("sink")
+
+	f.Setup("install sink", eventshub.Install(sink, eventshub.StartReceiver))
+	f.Setup("install channel", channel_impl.Install(channelName))
+	f.Setup("install subscription", subscription.Install(sub,
+		subscription.WithChannel(channel_impl.AsRef(channelName)),
+		subscription.WithSubscriber(service.AsKReference(sink), ""),
+	))
+
+	f.Setup("subscription is ready", subscription.IsReady(sub))
+	f.Setup("channel is ready", channel_impl.IsReady(channelName))
+
+	f.Requirement("install event sender", eventshub.Install(sender,
+		eventshub.StartSenderToResource(channel_impl.GVR(), channelName),
+		eventshub.InputEvent(event),
+	))
+
+	expectedTypes := sets.New(event.Type())
+
+	f.Alpha("imc").
+		Must("deliver events to subscriber", assert.OnStore(sink).MatchEvent(cetest.HasId(event.ID())).AtLeast(1)).
+		Must("create event type", eventtype.WaitForEventType(eventtype.AssertPresent(expectedTypes)))
+
+	return f
+}

--- a/test/experimental/features/eventtype_autocreate/features.go
+++ b/test/experimental/features/eventtype_autocreate/features.go
@@ -14,24 +14,17 @@ limitations under the License.
 package eventtype_autocreate
 
 import (
-	"context"
-
-	"github.com/cloudevents/sdk-go/v2/test"
 	cetest "github.com/cloudevents/sdk-go/v2/test"
 	"k8s.io/apimachinery/pkg/util/sets"
-	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	"knative.dev/eventing/test/rekt/resources/broker"
 	"knative.dev/eventing/test/rekt/resources/channel_impl"
 	"knative.dev/eventing/test/rekt/resources/eventtype"
-	"knative.dev/eventing/test/rekt/resources/pingsource"
 	"knative.dev/eventing/test/rekt/resources/subscription"
 	"knative.dev/eventing/test/rekt/resources/trigger"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/eventshub/assert"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/k8s"
-	"knative.dev/reconciler-test/pkg/manifest"
 	"knative.dev/reconciler-test/pkg/resources/service"
 )
 
@@ -96,46 +89,6 @@ func AutoCreateEventTypesOnBroker(brokerName string) *feature.Feature {
 	f.Alpha("broker").
 		Must("deliver events to subscriber", assert.OnStore(sink).MatchEvent(cetest.HasId(event.ID())).AtLeast(1)).
 		Must("create event type", eventtype.WaitForEventType(eventtype.AssertExactPresent(expectedTypes)))
-
-	return f
-}
-
-func AutoCreateEventTypeEventsFromPingSource() *feature.Feature {
-	source := feature.MakeRandomK8sName("source")
-	sink := feature.MakeRandomK8sName("sink")
-	via := feature.MakeRandomK8sName("via")
-
-	f := new(feature.Feature)
-
-	//Install the broker
-	brokerName := feature.MakeRandomK8sName("broker")
-	f.Setup("install broker", broker.Install(brokerName, broker.WithEnvConfig()...))
-	f.Setup("broker is ready", broker.IsReady(brokerName))
-	f.Setup("broker is addressable", broker.IsAddressable(brokerName))
-	f.Setup("install sink", eventshub.Install(sink, eventshub.StartReceiver))
-	f.Setup("install trigger", trigger.Install(via, brokerName, trigger.WithSubscriber(service.AsKReference(sink), "")))
-	f.Setup("trigger goes ready", trigger.IsReady(via))
-
-	f.Requirement("install pingsource", func(ctx context.Context, t feature.T) {
-		brokeruri, err := broker.Address(ctx, brokerName)
-		if err != nil {
-			t.Error("failed to get address of broker", err)
-		}
-		cfg := []manifest.CfgFn{
-			pingsource.WithSink(&duckv1.Destination{URI: brokeruri.URL, CACerts: brokeruri.CACerts}),
-			pingsource.WithData("text/plain", "hello, world!"),
-		}
-		pingsource.Install(source, cfg...)(ctx, t)
-	})
-	f.Requirement("PingSource goes ready", pingsource.IsReady(source))
-
-	expectedCeTypes := sets.New(sourcesv1.PingSourceEventType)
-
-	f.Stable("pingsource as event source").
-		Must("delivers events on broker with URI", assert.OnStore(sink).MatchEvent(
-			test.HasType(sourcesv1.PingSourceEventType)).AtLeast(1)).
-		Must("PingSource test eventtypes match", eventtype.WaitForEventType(
-			eventtype.AssertPresent(expectedCeTypes)))
 
 	return f
 }

--- a/test/experimental/features/eventtype_autocreate/features.go
+++ b/test/experimental/features/eventtype_autocreate/features.go
@@ -88,7 +88,7 @@ func AutoCreateEventTypesOnBroker(brokerName string) *feature.Feature {
 
 	f.Alpha("broker").
 		Must("deliver events to subscriber", assert.OnStore(sink).MatchEvent(cetest.HasId(event.ID())).AtLeast(1)).
-		Must("create event type", eventtype.WaitForEventType(eventtype.AssertExactPresent(expectedTypes)))
+		Must("create event type", eventtype.WaitForEventType(eventtype.AssertPresent(expectedTypes)))
 
 	return f
 }

--- a/test/rekt/features/apiserversource/data_plane.go
+++ b/test/rekt/features/apiserversource/data_plane.go
@@ -309,7 +309,7 @@ func SendsEventsWithEventTypes() *feature.Feature {
 	})
 	f.Requirement("ApiServerSource goes ready", apiserversource.IsReady(source))
 
-	expectedCeTypes := sets.New(sources.ApiServerSourceEventReferenceModeTypes...)
+	expectedCeTypes := sets.New(sources.ApiServerSourceEventResourceModeTypes...)
 
 	f.Stable("ApiServerSource as event source").
 		Must("delivers events on broker with URI",

--- a/test/rekt/features/apiserversource/data_plane.go
+++ b/test/rekt/features/apiserversource/data_plane.go
@@ -309,7 +309,7 @@ func SendsEventsWithEventTypes() *feature.Feature {
 	})
 	f.Requirement("ApiServerSource goes ready", apiserversource.IsReady(source))
 
-	expectedCeTypes := sets.New(sources.ApiServerSourceEventReferenceModeTypes...)
+	expectedCeTypes := sets.NewString(sources.ApiServerSourceEventResourceModeTypes...)
 
 	f.Stable("ApiServerSource as event source").
 		Must("delivers events on broker with URI",

--- a/test/rekt/features/apiserversource/data_plane.go
+++ b/test/rekt/features/apiserversource/data_plane.go
@@ -309,7 +309,7 @@ func SendsEventsWithEventTypes() *feature.Feature {
 	})
 	f.Requirement("ApiServerSource goes ready", apiserversource.IsReady(source))
 
-	expectedCeTypes := sets.NewString(sources.ApiServerSourceEventResourceModeTypes...)
+	expectedCeTypes := sets.New(sources.ApiServerSourceEventReferenceModeTypes...)
 
 	f.Stable("ApiServerSource as event source").
 		Must("delivers events on broker with URI",

--- a/test/rekt/features/pingsource/features.go
+++ b/test/rekt/features/pingsource/features.go
@@ -39,14 +39,10 @@ import (
 	"knative.dev/reconciler-test/pkg/eventshub/assert"
 	eventassert "knative.dev/reconciler-test/pkg/eventshub/assert"
 
-	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	"knative.dev/eventing/test/rekt/features"
 	"knative.dev/eventing/test/rekt/features/featureflags"
 	"knative.dev/eventing/test/rekt/features/source"
-	"knative.dev/eventing/test/rekt/resources/broker"
-	"knative.dev/eventing/test/rekt/resources/eventtype"
 	"knative.dev/eventing/test/rekt/resources/pingsource"
-	"knative.dev/eventing/test/rekt/resources/trigger"
 )
 
 func SendsEventsWithSinkRef() *feature.Feature {

--- a/test/rekt/features/pingsource/features.go
+++ b/test/rekt/features/pingsource/features.go
@@ -18,7 +18,7 @@ package pingsource
 
 import (
 	"context"
-
+	
 	"k8s.io/apimachinery/pkg/util/sets"
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	"knative.dev/eventing/test/rekt/resources/broker"
@@ -206,7 +206,7 @@ func SendsEventsWithEventTypes() *feature.Feature {
 	})
 	f.Requirement("PingSource goes ready", pingsource.IsReady(source))
 
-	expectedCeTypes := sets.New(sourcesv1.PingSourceEventType)
+	expectedCeTypes := sets.NewString(sourcesv1.PingSourceEventType)
 
 	f.Stable("pingsource as event source").
 		Must("delivers events on broker with URI", assert.OnStore(sink).MatchEvent(

--- a/test/rekt/features/pingsource/features.go
+++ b/test/rekt/features/pingsource/features.go
@@ -18,14 +18,6 @@ package pingsource
 
 import (
 	"context"
-	
-	"k8s.io/apimachinery/pkg/util/sets"
-	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
-	"knative.dev/eventing/test/rekt/resources/broker"
-	"knative.dev/eventing/test/rekt/resources/eventtype"
-	"knative.dev/eventing/test/rekt/resources/trigger"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
-	"knative.dev/reconciler-test/pkg/manifest"
 
 	"github.com/cloudevents/sdk-go/v2/test"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -35,6 +27,7 @@ import (
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/manifest"
 	"knative.dev/reconciler-test/pkg/resources/service"
 
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
@@ -46,10 +39,14 @@ import (
 	"knative.dev/reconciler-test/pkg/eventshub/assert"
 	eventassert "knative.dev/reconciler-test/pkg/eventshub/assert"
 
+	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	"knative.dev/eventing/test/rekt/features"
 	"knative.dev/eventing/test/rekt/features/featureflags"
 	"knative.dev/eventing/test/rekt/features/source"
+	"knative.dev/eventing/test/rekt/resources/broker"
+	"knative.dev/eventing/test/rekt/resources/eventtype"
 	"knative.dev/eventing/test/rekt/resources/pingsource"
+	"knative.dev/eventing/test/rekt/resources/trigger"
 )
 
 func SendsEventsWithSinkRef() *feature.Feature {

--- a/test/rekt/features/pingsource/features.go
+++ b/test/rekt/features/pingsource/features.go
@@ -18,7 +18,7 @@ package pingsource
 
 import (
 	"context"
-	
+
 	"k8s.io/apimachinery/pkg/util/sets"
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	"knative.dev/eventing/test/rekt/resources/broker"
@@ -206,7 +206,7 @@ func SendsEventsWithEventTypes() *feature.Feature {
 	})
 	f.Requirement("PingSource goes ready", pingsource.IsReady(source))
 
-	expectedCeTypes := sets.NewString(sourcesv1.PingSourceEventType)
+	expectedCeTypes := sets.New(sourcesv1.PingSourceEventType)
 
 	f.Stable("pingsource as event source").
 		Must("delivers events on broker with URI", assert.OnStore(sink).MatchEvent(

--- a/test/rekt/features/pingsource/features.go
+++ b/test/rekt/features/pingsource/features.go
@@ -203,7 +203,7 @@ func SendsEventsWithEventTypes() *feature.Feature {
 	})
 	f.Requirement("PingSource goes ready", pingsource.IsReady(source))
 
-	expectedCeTypes := sets.NewString(sourcesv1.PingSourceEventType)
+	expectedCeTypes := sets.New(sourcesv1.PingSourceEventType)
 
 	f.Stable("pingsource as event source").
 		Must("delivers events on broker with URI", assert.OnStore(sink).MatchEvent(

--- a/test/rekt/features/pingsource/features.go
+++ b/test/rekt/features/pingsource/features.go
@@ -18,6 +18,14 @@ package pingsource
 
 import (
 	"context"
+	
+	"k8s.io/apimachinery/pkg/util/sets"
+	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
+	"knative.dev/eventing/test/rekt/resources/broker"
+	"knative.dev/eventing/test/rekt/resources/eventtype"
+	"knative.dev/eventing/test/rekt/resources/trigger"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/reconciler-test/pkg/manifest"
 
 	"github.com/cloudevents/sdk-go/v2/test"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -27,7 +35,6 @@ import (
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/feature"
-	"knative.dev/reconciler-test/pkg/manifest"
 	"knative.dev/reconciler-test/pkg/resources/service"
 
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"

--- a/test/rekt/pingsource_test.go
+++ b/test/rekt/pingsource_test.go
@@ -21,6 +21,7 @@ package rekt
 
 import (
 	"testing"
+	"time"
 
 	"knative.dev/pkg/system"
 	"knative.dev/reconciler-test/pkg/environment"
@@ -89,4 +90,19 @@ func TestPingSourceWithCloudEventData(t *testing.T) {
 	)
 
 	env.Test(ctx, t, pingsource.SendsEventsWithCloudEventData())
+}
+
+func TestPingSourceWithEventTypes(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+		environment.WithPollTimings(5*time.Second, 2*time.Minute),
+	)
+
+	env.Test(ctx, t, pingsource.SendsEventsWithEventTypes())
 }

--- a/test/rekt/pingsource_test.go
+++ b/test/rekt/pingsource_test.go
@@ -21,7 +21,6 @@ package rekt
 
 import (
 	"testing"
-	"time"
 
 	"knative.dev/pkg/system"
 	"knative.dev/reconciler-test/pkg/environment"
@@ -90,19 +89,4 @@ func TestPingSourceWithCloudEventData(t *testing.T) {
 	)
 
 	env.Test(ctx, t, pingsource.SendsEventsWithCloudEventData())
-}
-
-func TestPingSourceWithEventTypes(t *testing.T) {
-	t.Parallel()
-
-	ctx, env := global.Environment(
-		knative.WithKnativeNamespace(system.Namespace()),
-		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
-		k8s.WithEventListener,
-		environment.Managed(t),
-		environment.WithPollTimings(5*time.Second, 2*time.Minute),
-	)
-
-	env.Test(ctx, t, pingsource.SendsEventsWithEventTypes())
 }

--- a/test/rekt/resources/eventtype/eventtype.go
+++ b/test/rekt/resources/eventtype/eventtype.go
@@ -60,7 +60,7 @@ func WaitForEventType(eventtype EventType, timing ...time.Duration) feature.Step
 	}
 }
 
-func AssertPresent(expectedCeTypes sets.String) EventType {
+func AssertPresent(expectedCeTypes sets.Set[string]) EventType {
 	return EventType{
 		Name: "test eventtypes match or not",
 		EventTypes: func(etl eventingv1beta2.EventTypeList) (bool, error) {

--- a/test/rekt/resources/eventtype/eventtype.go
+++ b/test/rekt/resources/eventtype/eventtype.go
@@ -60,7 +60,7 @@ func WaitForEventType(eventtype EventType, timing ...time.Duration) feature.Step
 	}
 }
 
-func AssertPresent(expectedCeTypes sets.Set[string]) EventType {
+func AssertPresent(expectedCeTypes sets.String) EventType {
 	return EventType{
 		Name: "test eventtypes match or not",
 		EventTypes: func(etl eventingv1beta2.EventTypeList) (bool, error) {

--- a/test/rekt/resources/eventtype/eventtype.go
+++ b/test/rekt/resources/eventtype/eventtype.go
@@ -73,21 +73,5 @@ func AssertPresent(expectedCeTypes sets.String) EventType {
 			return (eventtypesCount == len(etl.Items)), nil
 		},
 	}
-}
 
-func AssertExactPresent(expectedCeTypes sets.Set[string]) EventType {
-	return EventType{
-		Name: "test eventtypes match or not",
-		EventTypes: func(etl eventingv1beta2.EventTypeList) (bool, error) {
-			// Clone the expectedCeTypes
-			clonedExpectedCeTypes := expectedCeTypes.Clone()
-			for _, et := range etl.Items {
-				if !clonedExpectedCeTypes.Has(et.Spec.Type) {
-					return false, nil
-				}
-				clonedExpectedCeTypes.Delete(et.Spec.Type) // remove from the cloned set
-			}
-			return clonedExpectedCeTypes.Len() == 0, nil
-		},
-	}
 }

--- a/test/rekt/resources/eventtype/eventtype.go
+++ b/test/rekt/resources/eventtype/eventtype.go
@@ -73,5 +73,21 @@ func AssertPresent(expectedCeTypes sets.Set[string]) EventType {
 			return (eventtypesCount == len(etl.Items)), nil
 		},
 	}
+}
 
+func AssertExactPresent(expectedCeTypes sets.Set[string]) EventType {
+	return EventType{
+		Name: "test eventtypes match or not",
+		EventTypes: func(etl eventingv1beta2.EventTypeList) (bool, error) {
+			// Clone the expectedCeTypes
+			clonedExpectedCeTypes := expectedCeTypes.Clone()
+			for _, et := range etl.Items {
+				if !clonedExpectedCeTypes.Has(et.Spec.Type) {
+					return false, nil
+				}
+				clonedExpectedCeTypes.Delete(et.Spec.Type) // remove from the cloned set
+			}
+			return clonedExpectedCeTypes.Len() == 0, nil
+		},
+	}
 }


### PR DESCRIPTION
Backport following changes from upstream.
* [Added rekt test for channel event autocreate](https://github.com/openshift-knative/eventing/commit/76cdd558d038762c2bc59b6522d409b852228088)
* [Added rekt test for broker eventtype autocreate](https://github.com/openshift-knative/eventing/commit/16e428360070cc66a4ffea73facd879283c30893)
* [change the deprecated string](https://github.com/openshift-knative/eventing/commit/76592277eb7b84330d6c61f934429b9653072b41)
* [Generalize description of EventType in CRD.](https://github.com/openshift-knative/eventing/commit/98879267c2fc66ff8e1d8afa3edf3a676dcda4a4)

Introduce midstream scripts for executing experimental reconciler tests.  They're currently not executed in CI but will be re-used for downstream testing. In the future, they can be enabled in midstream if required.