### PR TITLE
Scripts for executing experimental reconciler tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ test-reconciler:
 	sh openshift/e2e-rekt-tests.sh
 .PHONY: test-reconciler
 
+test-experimental:
+	sh openshift/e2e-experimental-tests.sh
+.PHONY: test-experimental
+
 # Target used by github actions.
 test-images:
 	for img in $(TEST_IMAGES); do \

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -199,7 +199,9 @@ function run_conformance_tests(){
 function run_e2e_rekt_experimental_tests(){
   header "Running E2E experimental Tests"
 
-  oc patch knativeeventing --type merge -n "${EVENTING_NAMESPACE}" knative-eventing --patch-file "${SCRIPT_DIR}/knative-eventing-experimental.yaml"
+  local script_dir; script_dir="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+  oc patch knativeeventing --type merge -n "${EVENTING_NAMESPACE}" knative-eventing --patch-file "${script_dir}/knative-eventing-experimental.yaml"
 
   images_file=$(dirname $(realpath "$0"))/images.yaml
   make generate-release

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -195,3 +195,27 @@ function run_conformance_tests(){
 
   return $failed
 }
+
+function run_e2e_rekt_experimental_tests(){
+  header "Running E2E experimental Tests"
+
+  oc patch knativeeventing --type merge -n "${EVENTING_NAMESPACE}" knative-eventing --patch-file "${SCRIPT_DIR}/knative-eventing-experimental.yaml"
+
+  images_file=$(dirname $(realpath "$0"))/images.yaml
+  make generate-release
+  cat "${images_file}"
+
+  oc wait --for=condition=Ready knativeeventing.operator.knative.dev knative-eventing -n "${EVENTING_NAMESPACE}" --timeout=900s
+
+  local failed=0
+
+  # check for test flags
+  RUN_FLAGS="-timeout=1h -parallel=20"
+  if [ -n "${EVENTING_TEST_FLAGS:-}" ]; then
+    RUN_FLAGS="${EVENTING_TEST_FLAGS}"
+  fi
+
+  go_test_e2e ${RUN_FLAGS} ./test/experimental --images.producer.file="${images_file}" || failed=$?
+
+  return $failed
+}

--- a/openshift/e2e-experimental-tests.sh
+++ b/openshift/e2e-experimental-tests.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1090
+source "$(dirname "$0")/../vendor/knative.dev/hack/e2e-tests.sh"
+source "$(dirname "$0")/e2e-common.sh"
+
+set -Eeuox pipefail
+
+export TEST_IMAGE_TEMPLATE="${EVENTING_TEST_IMAGE_TEMPLATE}"
+
+env
+
+failed=0
+
+(( !failed )) && install_serverless || failed=1
+
+(( !failed )) && run_e2e_rekt_experimental_tests || failed=1
+
+(( failed )) && dump_cluster_state
+
+(( failed )) && exit 1
+
+success
+

--- a/openshift/knative-eventing-experimental.yaml
+++ b/openshift/knative-eventing-experimental.yaml
@@ -1,0 +1,8 @@
+spec:
+  config:
+    config-features:
+      kreference-group: "enabled"
+      delivery-retryafter: "enabled"
+      delivery-timeout: "enabled"
+      new-trigger-filters: "enabled"
+      eventtype-auto-create: "enabled"


### PR DESCRIPTION
These scripts are already included in PRs for [release-v1.12](https://github.com/openshift-knative/eventing/pull/511) and [release-v1.11](https://github.com/openshift-knative/eventing/pull/510).