### PR TITLE
[release-v1.11] backport receiver trace step annotation

### DIFF
--- a/test/upgrade/prober/wathola/receiver/services.go
+++ b/test/upgrade/prober/wathola/receiver/services.go
@@ -70,6 +70,7 @@ func (r receiver) receiveEvent(ctx context.Context, e cloudevents.Event) {
 		if err != nil {
 			log.Fatal(err)
 		}
+		span.AddAttributes(trace.Int64Attribute("step", int64(step.Number)))
 		r.step.RegisterStep(step)
 	}
 	if t == event.FinishedType {


### PR DESCRIPTION
backports https://github.com/knative/eventing/pull/7667

same as https://github.com/openshift-knative/eventing/pull/528 , which is for 1.13, but getting 1.11 first