### PR TITLE
[release-v1.13] Ocp bundle injection apiserversoure 1.13

### DIFF
--- a/pkg/reconciler/apiserversource/apiserversource.go
+++ b/pkg/reconciler/apiserversource/apiserversource.go
@@ -254,6 +254,12 @@ func (r *Reconciler) createReceiveAdapter(ctx context.Context, src *v1.ApiServer
 		msg := "Deployment created"
 		if err != nil {
 			msg = fmt.Sprint("Deployment created, error:", err)
+		} else {
+			// make CM only on clean creation
+			err := r.ensureCaTrustBundleConfigMap(ctx, src, adapterArgs)
+			if err != nil {
+				return nil, err
+			}
 		}
 		controller.GetEventRecorder(ctx).Eventf(src, corev1.EventTypeNormal, apiserversourceDeploymentCreated, "%s", msg)
 		return ra, err
@@ -272,6 +278,20 @@ func (r *Reconciler) createReceiveAdapter(ctx context.Context, src *v1.ApiServer
 		logging.FromContext(ctx).Debugw("Reusing existing receive adapter", zap.Any("receiveAdapter", ra))
 	}
 	return ra, nil
+}
+
+func (r *Reconciler) ensureCaTrustBundleConfigMap(ctx context.Context, src *v1.ApiServerSource, adapterArgs resources.ReceiveAdapterArgs) error {
+	_, err := r.kubeClientSet.CoreV1().ConfigMaps(src.Namespace).Get(ctx, resources.TrustedCAConfigMapName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		trustedBundleCM := resources.MakeTrustedCABundleConfigMap(&adapterArgs)
+
+		_, err := r.kubeClientSet.CoreV1().ConfigMaps(src.Namespace).Create(ctx, trustedBundleCM, metav1.CreateOptions{})
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("error creating trusted CA bundle configmap: %v", err)
+		}
+	}
+
+	return nil
 }
 
 func (r *Reconciler) podSpecChanged(oldPodSpec corev1.PodSpec, newPodSpec corev1.PodSpec) bool {

--- a/pkg/reconciler/apiserversource/resources/cabundle_configmap.go
+++ b/pkg/reconciler/apiserversource/resources/cabundle_configmap.go
@@ -1,0 +1,31 @@
+package resources
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/kmeta"
+)
+
+const (
+	// user-provided and system CA certificates
+	TrustedCAConfigMapName   = "config-openshift-trusted-cabundle"
+	TrustedCAConfigMapVolume = TrustedCAConfigMapName + "-volume"
+	TrustedCAKey             = "ca-bundle.crt"
+)
+
+func MakeTrustedCABundleConfigMap(args *ReceiveAdapterArgs) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      TrustedCAConfigMapName,
+			Namespace: args.Source.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "knative-eventing",
+				// user-provided and system CA certificates
+				"config.openshift.io/inject-trusted-cabundle": "true",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				*kmeta.NewControllerRef(args.Source),
+			},
+		},
+	}
+}

--- a/pkg/reconciler/apiserversource/resources/receive_adapter.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter.go
@@ -36,6 +36,10 @@ import (
 	reconcilersource "knative.dev/eventing/pkg/reconciler/source"
 )
 
+const (
+	OcpTrusedCaBundleMountPath = "/ocp-serverless-custom-certs"
+)
+
 // ReceiveAdapterArgs are the arguments needed to create a ApiServer Receive Adapter.
 // Every field is required.
 type ReceiveAdapterArgs struct {
@@ -84,6 +88,22 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) (*appsv1.Deployment, error) {
 				Spec: corev1.PodSpec{
 					ServiceAccountName: args.Source.Spec.ServiceAccountName,
 					EnableServiceLinks: ptr.Bool(false),
+					Volumes: []corev1.Volume{
+						{
+							Name: TrustedCAConfigMapVolume,
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: TrustedCAConfigMapName},
+									Items: []corev1.KeyToPath{
+										{
+											Key:  TrustedCAKey,
+											Path: TrustedCAKey,
+										},
+									},
+								},
+							},
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							Name:  "receive-adapter",
@@ -108,6 +128,13 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) (*appsv1.Deployment, error) {
 								ReadOnlyRootFilesystem:   ptr.Bool(true),
 								RunAsNonRoot:             ptr.Bool(true),
 								Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      TrustedCAConfigMapVolume,
+									MountPath: OcpTrusedCaBundleMountPath,
+									ReadOnly:  true,
+								},
 							},
 						},
 					},

--- a/pkg/reconciler/apiserversource/resources/receive_adapter.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	OcpTrusedCaBundleMountPath = "/ocp-serverless-custom-certs"
+	OcpTrusedCaBundleMountPath = "/ocp-serverless-custom-certs/" + TrustedCAKey
 )
 
 // ReceiveAdapterArgs are the arguments needed to create a ApiServer Receive Adapter.
@@ -133,6 +133,7 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) (*appsv1.Deployment, error) {
 								{
 									Name:      TrustedCAConfigMapVolume,
 									MountPath: OcpTrusedCaBundleMountPath,
+									SubPath:   TrustedCAKey,
 									ReadOnly:  true,
 								},
 							},

--- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
@@ -135,6 +135,22 @@ O2dgzikq8iSy1BlRsVw=
 				Spec: corev1.PodSpec{
 					ServiceAccountName: "source-svc-acct",
 					EnableServiceLinks: ptr.Bool(false),
+					Volumes: []corev1.Volume{
+						{
+							Name: TrustedCAConfigMapVolume,
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: TrustedCAConfigMapName},
+									Items: []corev1.KeyToPath{
+										{
+											Key:  TrustedCAKey,
+											Path: TrustedCAKey,
+										},
+									},
+								},
+							},
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							Name:  "receive-adapter",
@@ -195,6 +211,13 @@ O2dgzikq8iSy1BlRsVw=
 								ReadOnlyRootFilesystem:   ptr.Bool(true),
 								RunAsNonRoot:             ptr.Bool(true),
 								Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      TrustedCAConfigMapVolume,
+									MountPath: OcpTrusedCaBundleMountPath,
+									ReadOnly:  true,
+								},
 							},
 						},
 					},

--- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
@@ -216,6 +216,7 @@ O2dgzikq8iSy1BlRsVw=
 								{
 									Name:      TrustedCAConfigMapVolume,
 									MountPath: OcpTrusedCaBundleMountPath,
+									SubPath:   TrustedCAKey,
 									ReadOnly:  true,
 								},
 							},


### PR DESCRIPTION
Porting back to 1.13 these two PRs:
* https://github.com/openshift-knative/eventing/pull/441
* https://github.com/openshift-knative/eventing/pull/506

This brings in the two merged `sha`s, as `git cherry-pick` :cherries: :
* `gcp` 958f85c43970bc55056065045b9755eb5655a85d
* `gcp` 74d770792e7a5b7e3933d77d1e665f1726c5f542


(FWIW, the 506 was done to improve 441)

NEXT: Separate PR that adds this as a patch to `main`, to be always included 