### PR TITLE
[release-v1.13] Add owning-component annotation to config-openshift-trusted-cabundle ConfigMap

### DIFF
--- a/config/openshift-trusted-cabundle.yaml
+++ b/config/openshift-trusted-cabundle.yaml
@@ -22,3 +22,5 @@ metadata:
     app.kubernetes.io/name: knative-eventing
     config.openshift.io/inject-trusted-cabundle: "true"
     networking.knative.dev/trust-bundle: "true"
+  annotations:
+    "openshift.io/owning-component": "Serverless Operator"

--- a/openshift/release/artifacts/eventing-core.yaml
+++ b/openshift/release/artifacts/eventing-core.yaml
@@ -5278,3 +5278,5 @@ metadata:
     app.kubernetes.io/name: knative-eventing
     config.openshift.io/inject-trusted-cabundle: "true"
     networking.knative.dev/trust-bundle: "true"
+  annotations:
+    "openshift.io/owning-component": "Serverless Operator"


### PR DESCRIPTION
- Adds a label to our injected CA cluster bundle to avoid operator reconciliation war on OCP 4.15
- Values have to line up with cluster-network-operator as in https://github.com/openshift/cluster-network-operator/pull/2111

Not a real issue ATM, as we don't reconcile and update the `config-openshift-trusted-cabundle` CM, but to be prepared (following our discussions at [slack](https://redhat-internal.slack.com/archives/CEXRYS5QC/p1709648931178769))...

/assign @matzew @ReToCode 