### PR TITLE
Add owning-component annotation to config-openshift-trusted-cabundle ConfigMap

### DIFF
--- a/openshift/patches/023-configmap-trusted-cabundle.patch
+++ b/openshift/patches/023-configmap-trusted-cabundle.patch
@@ -28,4 +28,6 @@ index 000000000..a4c1a5f73
 +    app.kubernetes.io/name: knative-eventing
 +    config.openshift.io/inject-trusted-cabundle: "true"
 +    networking.knative.dev/trust-bundle: "true"
++  annotations:
++    "openshift.io/owning-component": "Serverless Operator"
 --


### PR DESCRIPTION
- Adds a label to our injected CA cluster bundle to avoid operator reconciliation war on OCP 4.15
- Values have to line up with cluster-network-operator as in https://github.com/openshift/cluster-network-operator/pull/2111

Not a real issue ATM, as we don't reconcile and update the `config-openshift-trusted-cabundle` CM, but to be prepared (following our discussions at [slack](https://redhat-internal.slack.com/archives/CEXRYS5QC/p1709648931178769))...

/assign @matzew @ReToCode 