### PR TITLE
[release-v1.11] Add owning-component annotation to config-openshift-trusted-cabundle ConfigMap

### DIFF
--- a/config/openshift-trusted-cabundle.yaml
+++ b/config/openshift-trusted-cabundle.yaml
@@ -22,3 +22,5 @@ metadata:
     app.kubernetes.io/name: knative-eventing
     config.openshift.io/inject-trusted-cabundle: "true"
     networking.knative.dev/trust-bundle: "true"
+  annotations:
+    "openshift.io/owning-component": "Serverless Operator"

--- a/openshift/release/artifacts/eventing-core.yaml
+++ b/openshift/release/artifacts/eventing-core.yaml
@@ -5061,3 +5061,5 @@ metadata:
     app.kubernetes.io/name: knative-eventing
     config.openshift.io/inject-trusted-cabundle: "true"
     networking.knative.dev/trust-bundle: "true"
+  annotations:
+    "openshift.io/owning-component": "Serverless Operator"


### PR DESCRIPTION
Same as https://github.com/openshift-knative/eventing/pull/559 but for 1.11