### PR TITLE
Fix receive_adapter patches after upstream updates

### DIFF
--- a/openshift/patches/023-apiserversource-configmap-trusted-cabundle.patch
+++ b/openshift/patches/023-apiserversource-configmap-trusted-cabundle.patch
@@ -89,13 +89,13 @@ index 00000000000..5091d3d39f9
 +	}
 +}
 diff --git a/pkg/reconciler/apiserversource/resources/receive_adapter.go b/pkg/reconciler/apiserversource/resources/receive_adapter.go
-index 6b19bbbb0e1..40148851e34 100644
+index 6b3bfe082..bb14eefc9 100644
 --- a/pkg/reconciler/apiserversource/resources/receive_adapter.go
 +++ b/pkg/reconciler/apiserversource/resources/receive_adapter.go
 @@ -36,6 +36,10 @@ import (
  	reconcilersource "knative.dev/eventing/pkg/reconciler/source"
  )
- 
+
 +const (
 +	OcpTrusedCaBundleMountPath = "/ocp-serverless-custom-certs"
 +)
@@ -103,8 +103,8 @@ index 6b19bbbb0e1..40148851e34 100644
  // ReceiveAdapterArgs are the arguments needed to create a ApiServer Receive Adapter.
  // Every field is required.
  type ReceiveAdapterArgs struct {
-@@ -84,6 +88,22 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) (*appsv1.Deployment, error) {
- 				Spec: corev1.PodSpec{
+@@ -86,6 +90,22 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) (*appsv1.Deployment, error) {
+ 					NodeSelector:       args.NodeSelector,
  					ServiceAccountName: args.Source.Spec.ServiceAccountName,
  					EnableServiceLinks: ptr.Bool(false),
 +					Volumes: []corev1.Volume{
@@ -126,9 +126,9 @@ index 6b19bbbb0e1..40148851e34 100644
  					Containers: []corev1.Container{
  						{
  							Name:  "receive-adapter",
-@@ -109,6 +129,13 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) (*appsv1.Deployment, error) {
- 								RunAsNonRoot:             ptr.Bool(true),
+@@ -112,6 +132,13 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) (*appsv1.Deployment, error) {
  								Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+ 								SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
  							},
 +							VolumeMounts: []corev1.VolumeMount{
 +								{
@@ -141,7 +141,7 @@ index 6b19bbbb0e1..40148851e34 100644
  					},
  				},
 diff --git a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
-index 424d747e7fc..9de5c4a79cd 100644
+index 55c2817e5..0b03776d2 100644
 --- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
 +++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
 @@ -135,6 +135,22 @@ O2dgzikq8iSy1BlRsVw=
@@ -167,9 +167,9 @@ index 424d747e7fc..9de5c4a79cd 100644
  					Containers: []corev1.Container{
  						{
  							Name:  "receive-adapter",
-@@ -196,6 +212,13 @@ O2dgzikq8iSy1BlRsVw=
- 								RunAsNonRoot:             ptr.Bool(true),
+@@ -197,6 +213,13 @@ O2dgzikq8iSy1BlRsVw=
  								Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+ 								SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
  							},
 +							VolumeMounts: []corev1.VolumeMount{
 +								{

--- a/openshift/patches/remove_seccompProfile.patch
+++ b/openshift/patches/remove_seccompProfile.patch
@@ -165,26 +165,26 @@ index 844c39845..1a590f667 100644
    sink:
      ref:
 diff --git a/pkg/reconciler/apiserversource/resources/receive_adapter.go b/pkg/reconciler/apiserversource/resources/receive_adapter.go
-index 83c784317..38ad0b22b 100644
+index 5f5888de4..924746d2d 100644
 --- a/pkg/reconciler/apiserversource/resources/receive_adapter.go
 +++ b/pkg/reconciler/apiserversource/resources/receive_adapter.go
-@@ -108,7 +108,6 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) (*appsv1.Deployment, error) {
+@@ -130,7 +130,6 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) (*appsv1.Deployment, error) {
  								ReadOnlyRootFilesystem:   ptr.Bool(true),
  								RunAsNonRoot:             ptr.Bool(true),
  								Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
 -								SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
  							},
- 						},
- 					},
+ 							VolumeMounts: []corev1.VolumeMount{
+ 								{
 diff --git a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
-index 777ec5769..f8e35fd13 100644
+index 37a6cc217..bc22707d4 100644
 --- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
 +++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
-@@ -169,7 +169,6 @@ func TestMakeReceiveAdapters(t *testing.T) {
+@@ -211,7 +211,6 @@ O2dgzikq8iSy1BlRsVw=
  								ReadOnlyRootFilesystem:   ptr.Bool(true),
  								RunAsNonRoot:             ptr.Bool(true),
  								Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
 -								SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
  							},
- 						},
- 					},
+ 							VolumeMounts: []corev1.VolumeMount{
+ 								{


### PR DESCRIPTION
Fixes the current git apply issues in Jenkins: https://master-jenkins-csb-serverless-qe.apps.ocp-c1.prod.psi.redhat.com/job/ci/job/knative-nightly-ci-eventing/1130/console