### PR TITLE
[release-v1.12] Reduce the scope for the Config validation webhook to only the `knative-eventing` namespace. (#7792)

### DIFF
--- a/config/core/webhooks/config-validation.yaml
+++ b/config/core/webhooks/config-validation.yaml
@@ -30,4 +30,7 @@ webhooks:
   name: config.webhook.eventing.knative.dev
   namespaceSelector:
     matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: In
+        values: ["knative-eventing"]
   timeoutSeconds: 10


### PR DESCRIPTION
Config validation applies to system namespace only

The webhook is currently handling all ConfigMaps in the cluster.