### PR TITLE
[release-v1.14]: upgrade rekt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	knative.dev/hack v0.0.0-20240404013450-1133b37da8d7
 	knative.dev/hack/schema v0.0.0-20240404013450-1133b37da8d7
 	knative.dev/pkg v0.0.0-20240416145024-0f34a8815650
-	knative.dev/reconciler-test v0.0.0-20240417065737-ca905cbb09a9
+	knative.dev/reconciler-test v0.0.0-20240503125949-8fd5ae6217a3
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -891,8 +891,8 @@ knative.dev/hack/schema v0.0.0-20240404013450-1133b37da8d7 h1:MyFPlm1NkiCF7H8nKw
 knative.dev/hack/schema v0.0.0-20240404013450-1133b37da8d7/go.mod h1:3pWwBLnTZSM9psSgCAvhKOHIPTzqfEMlWRpDu6IYhK0=
 knative.dev/pkg v0.0.0-20240416145024-0f34a8815650 h1:m2ahFUO0L2VrgGDYdyOUFdE6xBd3pLXAJozLJwqLRQM=
 knative.dev/pkg v0.0.0-20240416145024-0f34a8815650/go.mod h1:soFw5ss08G4PU3JiFDKqiZRd2U7xoqcfNpJP1coIXkY=
-knative.dev/reconciler-test v0.0.0-20240417065737-ca905cbb09a9 h1:AuQT+6OU8R7QIMNBtViewLG6mkMbNlUwumy4gukpprc=
-knative.dev/reconciler-test v0.0.0-20240417065737-ca905cbb09a9/go.mod h1:xrX67/nfPlCu0UAt9OHCpI1ZlAF0rqLA5hZrB/xu63s=
+knative.dev/reconciler-test v0.0.0-20240503125949-8fd5ae6217a3 h1:kndnO/h0hG+M/sVqGysZHL9P4qXHzQ7ZmgzKXk0k8fg=
+knative.dev/reconciler-test v0.0.0-20240503125949-8fd5ae6217a3/go.mod h1:xrX67/nfPlCu0UAt9OHCpI1ZlAF0rqLA5hZrB/xu63s=
 pgregory.net/rapid v1.1.0 h1:CMa0sjHSru3puNx+J0MIAuiiEV4N0qj8/cMWGBBCsjw=
 pgregory.net/rapid v1.1.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/vendor/knative.dev/reconciler-test/pkg/eventshub/forwarder/forwarder.go
+++ b/vendor/knative.dev/reconciler-test/pkg/eventshub/forwarder/forwarder.go
@@ -17,8 +17,10 @@ limitations under the License.
 package forwarder
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -26,7 +28,6 @@ import (
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/cloudevents/sdk-go/v2/binding"
 	cloudeventsbindings "github.com/cloudevents/sdk-go/v2/binding"
 	"go.opencensus.io/trace"
 	"go.uber.org/zap"
@@ -127,10 +128,21 @@ func (o *Forwarder) ServeHTTP(writer http.ResponseWriter, request *http.Request)
 	requestCtx, span := trace.StartSpan(request.Context(), "eventshub-forwarder")
 	defer span.End()
 
+	body, err := io.ReadAll(request.Body)
+	if err != nil {
+		writer.WriteHeader(http.StatusInternalServerError)
+		logging.FromContext(o.ctx).Errorw("Failed to read request body", zap.Error(err))
+		return
+	}
+	_ = request.Body.Close()
+	request.Body = io.NopCloser(bytes.NewBuffer(body))
+
 	m := cloudeventshttp.NewMessageFromHttpRequest(request)
 	defer m.Finish(nil)
 
 	event, eventErr := cloudeventsbindings.ToEvent(context.TODO(), m)
+	request.Body = io.NopCloser(bytes.NewBuffer(body)) // reset body
+
 	receivedHeaders := make(http.Header)
 	for k, v := range request.Header {
 		if !strings.HasPrefix(k, "Ce-") {
@@ -174,11 +186,6 @@ func (o *Forwarder) ServeHTTP(writer http.ResponseWriter, request *http.Request)
 	}
 	req.URL = u
 
-	err = cehttp.WriteRequest(requestCtx, binding.ToMessage(event), req)
-	if err != nil {
-		logging.FromContext(o.ctx).Error("Cannot write the event to request: ", err)
-	}
-
 	eventString := "unknown"
 	if event != nil {
 		eventString = event.String()
@@ -202,7 +209,7 @@ func (o *Forwarder) ServeHTTP(writer http.ResponseWriter, request *http.Request)
 		}
 	}
 
-	writer.WriteHeader(http.StatusAccepted)
+	writer.WriteHeader(res.StatusCode)
 }
 
 func (o *Forwarder) sentInfo(event *cloudevents.Event, req *http.Request, err error) eventshub.EventInfo {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1381,7 +1381,7 @@ knative.dev/pkg/webhook/resourcesemantics
 knative.dev/pkg/webhook/resourcesemantics/conversion
 knative.dev/pkg/webhook/resourcesemantics/defaulting
 knative.dev/pkg/webhook/resourcesemantics/validation
-# knative.dev/reconciler-test v0.0.0-20240417065737-ca905cbb09a9
+# knative.dev/reconciler-test v0.0.0-20240503125949-8fd5ae6217a3
 ## explicit; go 1.21
 knative.dev/reconciler-test/cmd/eventshub
 knative.dev/reconciler-test/pkg/environment


### PR DESCRIPTION
Upgrade rekt to include the fix by @pierDipi to the event forwarder