### PR TITLE
[release-v1.12] Containersource use OIDC identity of corresponding SinkBinding

### DIFF
--- a/pkg/apis/sources/v1/container_lifecycle.go
+++ b/pkg/apis/sources/v1/container_lifecycle.go
@@ -63,7 +63,7 @@ func (s *ContainerSourceStatus) InitializeConditions() {
 	containerCondSet.Manage(s).InitializeConditions()
 }
 
-// PropagateSinkBindingStatus uses the availability of the provided Deployment to determine if
+// PropagateSinkBindingStatus uses the SinkBinding to determine if
 // ContainerSourceConditionSinkBindingReady should be marked as true, false or unknown.
 func (s *ContainerSourceStatus) PropagateSinkBindingStatus(status *SinkBindingStatus) {
 	// Do not copy conditions nor observedGeneration
@@ -86,6 +86,9 @@ func (s *ContainerSourceStatus) PropagateSinkBindingStatus(status *SinkBindingSt
 	default:
 		containerCondSet.Manage(s).MarkUnknown(ContainerSourceConditionSinkBindingReady, cond.Reason, cond.Message)
 	}
+
+	// Propagate SinkBindings AuthStatus to containersources AuthStatus
+	s.Auth = status.Auth
 }
 
 // PropagateReceiveAdapterStatus uses the availability of the provided Deployment to determine if

--- a/pkg/apis/sources/v1/container_lifecycle.go
+++ b/pkg/apis/sources/v1/container_lifecycle.go
@@ -31,14 +31,11 @@ const (
 
 	// ContainerSourceConditionReceiveAdapterReady has status True when the ContainerSource's ReceiveAdapter is ready.
 	ContainerSourceConditionReceiveAdapterReady apis.ConditionType = "ReceiveAdapterReady"
-
-	ContainerConditionOIDCIdentityCreated apis.ConditionType = "OIDCIdentityCreated"
 )
 
 var containerCondSet = apis.NewLivingConditionSet(
 	ContainerSourceConditionSinkBindingReady,
 	ContainerSourceConditionReceiveAdapterReady,
-	ContainerConditionOIDCIdentityCreated,
 )
 
 // GetConditionSet retrieves the condition set for this resource. Implements the KRShaped interface.
@@ -64,22 +61,6 @@ func (s *ContainerSourceStatus) IsReady() bool {
 // InitializeConditions sets relevant unset conditions to Unknown state.
 func (s *ContainerSourceStatus) InitializeConditions() {
 	containerCondSet.Manage(s).InitializeConditions()
-}
-
-func (s *ContainerSourceStatus) MarkOIDCIdentityCreatedSucceeded() {
-	containerCondSet.Manage(s).MarkTrue(ContainerConditionOIDCIdentityCreated)
-}
-
-func (s *ContainerSourceStatus) MarkOIDCIdentityCreatedSucceededWithReason(reason, messageFormat string, messageA ...interface{}) {
-	containerCondSet.Manage(s).MarkTrueWithReason(ContainerConditionOIDCIdentityCreated, reason, messageFormat, messageA...)
-}
-
-func (s *ContainerSourceStatus) MarkOIDCIdentityCreatedFailed(reason, messageFormat string, messageA ...interface{}) {
-	containerCondSet.Manage(s).MarkFalse(ContainerConditionOIDCIdentityCreated, reason, messageFormat, messageA...)
-}
-
-func (s *ContainerSourceStatus) MarkOIDCIdentityCreatedUnknown(reason, messageFormat string, messageA ...interface{}) {
-	containerCondSet.Manage(s).MarkUnknown(ContainerConditionOIDCIdentityCreated, reason, messageFormat, messageA...)
 }
 
 // PropagateSinkBindingStatus uses the availability of the provided Deployment to determine if

--- a/pkg/apis/sources/v1/container_lifecycle_test.go
+++ b/pkg/apis/sources/v1/container_lifecycle_test.go
@@ -105,35 +105,23 @@ func TestContainerSourceStatusIsReady(t *testing.T) {
 		wantConditionStatus: corev1.ConditionUnknown,
 		want:                false,
 	}, {
-		name: "mark ready sa",
-		s: func() *ContainerSourceStatus {
-			s := &ContainerSourceStatus{}
-			s.InitializeConditions()
-			s.MarkOIDCIdentityCreatedSucceeded()
-			return s
-		}(),
-		wantConditionStatus: corev1.ConditionUnknown,
-		want:                false,
-	}, {
 		name: "mark ready sb and ra",
 		s: func() *ContainerSourceStatus {
 			s := &ContainerSourceStatus{}
 			s.InitializeConditions()
 			s.PropagateSinkBindingStatus(&readySinkBinding.Status)
 			s.PropagateReceiveAdapterStatus(availableDeployment)
-			s.MarkOIDCIdentityCreatedSucceeded()
 			return s
 		}(),
 		wantConditionStatus: corev1.ConditionTrue,
 		want:                true,
 	}, {
-		name: "mark ready sb and unavailable ra ",
+		name: "mark ready sb and unavailable ra",
 		s: func() *ContainerSourceStatus {
 			s := &ContainerSourceStatus{}
 			s.InitializeConditions()
 			s.PropagateSinkBindingStatus(&readySinkBinding.Status)
 			s.PropagateReceiveAdapterStatus(unavailableDeployment)
-			s.MarkOIDCIdentityCreatedSucceeded()
 			return s
 		}(),
 		wantConditionStatus: corev1.ConditionFalse,
@@ -145,47 +133,10 @@ func TestContainerSourceStatusIsReady(t *testing.T) {
 			s.InitializeConditions()
 			s.PropagateSinkBindingStatus(&readySinkBinding.Status)
 			s.PropagateReceiveAdapterStatus(unknownDeployment)
-			s.MarkOIDCIdentityCreatedSucceeded()
 			return s
 		}(),
 		wantConditionStatus: corev1.ConditionUnknown,
 		want:                false,
-	}, {
-		name: "mark ready sb and ra no sa",
-		s: func() *ContainerSourceStatus {
-			s := &ContainerSourceStatus{}
-			s.InitializeConditions()
-			s.PropagateSinkBindingStatus(&readySinkBinding.Status)
-			s.PropagateReceiveAdapterStatus(availableDeployment)
-			s.MarkOIDCIdentityCreatedFailed("", "")
-			return s
-		}(),
-		wantConditionStatus: corev1.ConditionFalse,
-		want:                false,
-	}, {
-		name: "mark ready sb, ra and sa unknown",
-		s: func() *ContainerSourceStatus {
-			s := &ContainerSourceStatus{}
-			s.InitializeConditions()
-			s.PropagateSinkBindingStatus(&readySinkBinding.Status)
-			s.PropagateReceiveAdapterStatus(availableDeployment)
-			s.MarkOIDCIdentityCreatedUnknown("Unknown", "")
-			return s
-		}(),
-		wantConditionStatus: corev1.ConditionUnknown,
-		want:                false,
-	}, {
-		name: "mark ready sb, ra and sa with reason",
-		s: func() *ContainerSourceStatus {
-			s := &ContainerSourceStatus{}
-			s.InitializeConditions()
-			s.PropagateSinkBindingStatus(&readySinkBinding.Status)
-			s.PropagateReceiveAdapterStatus(availableDeployment)
-			s.MarkOIDCIdentityCreatedSucceededWithReason("Created", "")
-			return s
-		}(),
-		wantConditionStatus: corev1.ConditionTrue,
-		want:                true,
 	}, {
 		name: "mark ready sb and not deployed ra",
 		s: func() *ContainerSourceStatus {
@@ -193,7 +144,6 @@ func TestContainerSourceStatusIsReady(t *testing.T) {
 			s.InitializeConditions()
 			s.PropagateSinkBindingStatus(&readySinkBinding.Status)
 			s.PropagateReceiveAdapterStatus(&appsv1.Deployment{})
-			s.MarkOIDCIdentityCreatedSucceeded()
 			return s
 		}(),
 		wantConditionStatus: corev1.ConditionUnknown,
@@ -206,7 +156,6 @@ func TestContainerSourceStatusIsReady(t *testing.T) {
 			s.PropagateSinkBindingStatus(&readySinkBinding.Status)
 			s.PropagateReceiveAdapterStatus(availableDeployment)
 			s.PropagateSinkBindingStatus(&notReadySinkBinding.Status)
-			s.MarkOIDCIdentityCreatedSucceeded()
 			return s
 		}(),
 		wantConditionStatus: corev1.ConditionFalse,
@@ -219,7 +168,6 @@ func TestContainerSourceStatusIsReady(t *testing.T) {
 			s.PropagateReceiveAdapterStatus(availableDeployment)
 			s.PropagateSinkBindingStatus(&notReadySinkBinding.Status)
 			s.PropagateReceiveAdapterStatus(unavailableDeployment)
-			s.MarkOIDCIdentityCreatedSucceeded()
 			return s
 		}(),
 		wantConditionStatus: corev1.ConditionFalse,
@@ -231,7 +179,6 @@ func TestContainerSourceStatusIsReady(t *testing.T) {
 			s.InitializeConditions()
 			s.PropagateSinkBindingStatus(&notReadySinkBinding.Status)
 			s.PropagateReceiveAdapterStatus(availableDeployment)
-			s.MarkOIDCIdentityCreatedSucceeded()
 			return s
 		}(),
 		wantConditionStatus: corev1.ConditionFalse,
@@ -244,7 +191,6 @@ func TestContainerSourceStatusIsReady(t *testing.T) {
 			s.PropagateSinkBindingStatus(&notReadySinkBinding.Status)
 			s.PropagateReceiveAdapterStatus(availableDeployment)
 			s.PropagateSinkBindingStatus(&readySinkBinding.Status)
-			s.MarkOIDCIdentityCreatedSucceeded()
 			return s
 		}(),
 		wantConditionStatus: corev1.ConditionTrue,
@@ -258,7 +204,6 @@ func TestContainerSourceStatusIsReady(t *testing.T) {
 				if gotConditionStatus != test.wantConditionStatus {
 					t.Errorf("unexpected condition status: want %v, got %v", test.wantConditionStatus, gotConditionStatus)
 				}
-
 			}
 			got := test.s.IsReady()
 			if got != test.want {
@@ -318,26 +263,12 @@ func TestContainerSourceStatusGetCondition(t *testing.T) {
 			Status: corev1.ConditionUnknown,
 		},
 	}, {
-		name: "mark ready sa",
-		s: func() *ContainerSourceStatus {
-			s := &ContainerSourceStatus{}
-			s.InitializeConditions()
-			s.MarkOIDCIdentityCreatedSucceeded()
-			return s
-		}(),
-		condQuery: ContainerSourceConditionReady,
-		want: &apis.Condition{
-			Type:   ContainerSourceConditionReady,
-			Status: corev1.ConditionUnknown,
-		},
-	}, {
 		name: "mark ready sb and ra",
 		s: func() *ContainerSourceStatus {
 			s := &ContainerSourceStatus{}
 			s.InitializeConditions()
 			s.PropagateSinkBindingStatus(&readySinkBinding.Status)
 			s.PropagateReceiveAdapterStatus(availableDeployment)
-			s.MarkOIDCIdentityCreatedSucceeded()
 			return s
 		}(),
 		condQuery: ContainerSourceConditionReady,
@@ -353,7 +284,6 @@ func TestContainerSourceStatusGetCondition(t *testing.T) {
 			s.PropagateSinkBindingStatus(&readySinkBinding.Status)
 			s.PropagateReceiveAdapterStatus(availableDeployment)
 			s.PropagateSinkBindingStatus(&notReadySinkBinding.Status)
-			s.MarkOIDCIdentityCreatedSucceeded()
 			return s
 		}(),
 		condQuery: ContainerSourceConditionReady,
@@ -364,22 +294,6 @@ func TestContainerSourceStatusGetCondition(t *testing.T) {
 			Message: "hi",
 		},
 	}, {
-		name: "mark ready sb, ra and sa unknown",
-		s: func() *ContainerSourceStatus {
-			s := &ContainerSourceStatus{}
-			s.InitializeConditions()
-			s.PropagateSinkBindingStatus(&readySinkBinding.Status)
-			s.PropagateReceiveAdapterStatus(availableDeployment)
-			s.MarkOIDCIdentityCreatedUnknown("Unknown", "")
-			return s
-		}(),
-		condQuery: ContainerSourceConditionReady,
-		want: &apis.Condition{
-			Type:   ContainerSourceConditionReady,
-			Status: corev1.ConditionUnknown,
-			Reason: "Unknown",
-		},
-	}, {
 		name: "mark ready sb and ra then no ra",
 		s: func() *ContainerSourceStatus {
 			s := &ContainerSourceStatus{}
@@ -387,44 +301,12 @@ func TestContainerSourceStatusGetCondition(t *testing.T) {
 			s.PropagateSinkBindingStatus(&readySinkBinding.Status)
 			s.PropagateReceiveAdapterStatus(availableDeployment)
 			s.PropagateReceiveAdapterStatus(unavailableDeployment)
-			s.MarkOIDCIdentityCreatedSucceeded()
 			return s
 		}(),
 		condQuery: ContainerSourceConditionReady,
 		want: &apis.Condition{
 			Type:   ContainerSourceConditionReady,
 			Status: corev1.ConditionFalse,
-		},
-	}, {
-		name: "mark ready sb, sa and ra then no sa",
-		s: func() *ContainerSourceStatus {
-			s := &ContainerSourceStatus{}
-			s.InitializeConditions()
-			s.PropagateSinkBindingStatus(&readySinkBinding.Status)
-			s.PropagateReceiveAdapterStatus(availableDeployment)
-			s.MarkOIDCIdentityCreatedSucceeded()
-			s.MarkOIDCIdentityCreatedFailed("", "")
-			return s
-		}(),
-		condQuery: ContainerSourceConditionReady,
-		want: &apis.Condition{
-			Type:   ContainerSourceConditionReady,
-			Status: corev1.ConditionFalse,
-		},
-	}, {
-		name: "mark ready sb, ra and sa with reason",
-		s: func() *ContainerSourceStatus {
-			s := &ContainerSourceStatus{}
-			s.InitializeConditions()
-			s.PropagateSinkBindingStatus(&readySinkBinding.Status)
-			s.PropagateReceiveAdapterStatus(availableDeployment)
-			s.MarkOIDCIdentityCreatedSucceededWithReason("Created", "")
-			return s
-		}(),
-		condQuery: ContainerSourceConditionReady,
-		want: &apis.Condition{
-			Type:   ContainerSourceConditionReady,
-			Status: corev1.ConditionTrue,
 		},
 	}, {
 		name: "mark not ready sb and ready ra then ready sb",
@@ -434,7 +316,6 @@ func TestContainerSourceStatusGetCondition(t *testing.T) {
 			s.PropagateSinkBindingStatus(&notReadySinkBinding.Status)
 			s.PropagateReceiveAdapterStatus(availableDeployment)
 			s.PropagateSinkBindingStatus(&readySinkBinding.Status)
-			s.MarkOIDCIdentityCreatedSucceeded()
 			return s
 		}(),
 		condQuery: ContainerSourceConditionReady,

--- a/pkg/reconciler/containersource/containersource_test.go
+++ b/pkg/reconciler/containersource/containersource_test.go
@@ -29,23 +29,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgotesting "k8s.io/client-go/testing"
+	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
 	"knative.dev/pkg/apis"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	"knative.dev/pkg/logging"
 
-	"knative.dev/eventing/pkg/auth"
-	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
-
+	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
+	"knative.dev/eventing/pkg/client/injection/reconciler/sources/v1/containersource"
+	"knative.dev/eventing/pkg/reconciler/containersource/resources"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/client/injection/ducks/duck/v1/addressable"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
-
-	"knative.dev/eventing/pkg/apis/feature"
-	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
-	"knative.dev/eventing/pkg/client/injection/reconciler/sources/v1/containersource"
-	"knative.dev/eventing/pkg/reconciler/containersource/resources"
 
 	logtesting "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/reconciler/testing"
@@ -146,7 +142,6 @@ func TestAllCases(t *testing.T) {
 					WithContainerSourceSpec(makeContainerSourceSpec(sinkDest)),
 					WithContainerSourceObjectMetaGeneration(generation),
 					WithInitContainerSourceConditions,
-					WithContainerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 					WithContainerSourceStatusObservedGeneration(generation),
 				),
 			}},
@@ -181,7 +176,6 @@ func TestAllCases(t *testing.T) {
 					WithContainerSourceSpec(makeContainerSourceSpec(sinkDest)),
 					WithContainerSourceObjectMetaGeneration(generation),
 					WithInitContainerSourceConditions,
-					WithContainerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 					WithContainerSourceStatusObservedGeneration(generation),
 					WithContainerSourcePropagateReceiveAdapterStatus(makeDeployment(NewContainerSource(sourceName, testNS,
 						WithContainerSourceSpec(makeContainerSourceSpec(sinkDest)),
@@ -224,7 +218,6 @@ func TestAllCases(t *testing.T) {
 				Object: NewContainerSource(sourceName, testNS,
 					WithContainerSourceUID(sourceUID),
 					WithContainerSourceSpec(makeContainerSourceSpec(sinkDest)),
-					WithContainerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 					WithContainerSourceObjectMetaGeneration(generation),
 					WithInitContainerSourceConditions,
 					WithContainerSourceStatusObservedGeneration(generation),
@@ -235,83 +228,6 @@ func TestAllCases(t *testing.T) {
 					), &conditionTrue)),
 				),
 			}},
-		}, {
-			Name: "OIDC: creates OIDC service account",
-			Key:  testNS + "/" + sourceName,
-			Ctx: feature.ToContext(context.Background(), feature.Flags{
-				feature.OIDCAuthentication: feature.Enabled,
-			}),
-			Objects: []runtime.Object{
-				NewContainerSource(sourceName, testNS,
-					WithContainerSourceUID(sourceUID),
-					WithContainerSourceSpec(makeContainerSourceSpec(sinkDest)),
-					WithContainerSourceObjectMetaGeneration(generation),
-				),
-				makeSinkBinding(NewContainerSource(sourceName, testNS,
-					WithContainerSourceSpec(makeContainerSourceSpec(sinkDest)),
-					WithContainerSourceUID(sourceUID),
-				), &conditionTrue),
-				makeDeployment(NewContainerSource(sourceName, testNS,
-					WithContainerSourceSpec(makeContainerSourceSpec(sinkDest)),
-					WithContainerSourceUID(sourceUID),
-				), &conditionTrue),
-			},
-			WantErr: false,
-			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: NewContainerSource(sourceName, testNS,
-					WithContainerSourceUID(sourceUID),
-					WithContainerSourceSpec(makeContainerSourceSpec(sinkDest)),
-					WithContainerSourceObjectMetaGeneration(generation),
-					WithInitContainerSourceConditions,
-					WithContainerSourceStatusObservedGeneration(generation),
-					WithContainerSourcePropagateSinkbindingStatus(makeSinkBindingStatus(&conditionTrue)),
-					WithContainerSourcePropagateReceiveAdapterStatus(makeDeployment(NewContainerSource(sourceName, testNS,
-						WithContainerSourceSpec(makeContainerSourceSpec(sinkDest)),
-						WithContainerSourceUID(sourceUID),
-					), &conditionTrue)),
-					WithContainerSourceOIDCIdentityCreatedSucceeded(),
-					WithContainerSourceOIDCServiceAccountName(makeContainerSourceOIDCServiceAccount().Name),
-				),
-			}},
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, sourceReconciled, `ContainerSource reconciled: "%s/%s"`, testNS, sourceName),
-			},
-			WantCreates: []runtime.Object{
-				makeContainerSourceOIDCServiceAccount(),
-			},
-		}, {
-			Name: "OIDC: Containersource not ready on invalid OIDC service account",
-			Key:  testNS + "/" + sourceName,
-			Ctx: feature.ToContext(context.Background(), feature.Flags{
-				feature.OIDCAuthentication: feature.Enabled,
-			}),
-			Objects: []runtime.Object{
-				makeContainerSourceOIDCServiceAccountWithoutOwnerRef(),
-				makeSinkBinding(NewContainerSource(sourceName, testNS,
-					WithContainerSourceSpec(makeContainerSourceSpec(sinkDest)),
-					WithContainerSourceUID(sourceUID),
-				), nil),
-				NewContainerSource(sourceName, testNS,
-					WithContainerSourceUID(sourceUID),
-					WithContainerSourceSpec(makeContainerSourceSpec(sinkDest)),
-					WithContainerSourceObjectMetaGeneration(generation),
-				),
-			},
-			WantErr: true,
-			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: NewContainerSource(sourceName, testNS,
-					WithContainerSourceStatusObservedGeneration(generation),
-					WithContainerSourceObjectMetaGeneration(generation),
-					WithContainerSourceUID(sourceUID),
-					WithContainerSourceSpec(makeContainerSourceSpec(sinkDest)),
-					WithInitContainerSourceConditions,
-					WithContainerSourceOIDCIdentityCreatedFailed("Unable to resolve service account for OIDC authentication", fmt.Sprintf("service account %s not owned by ContainerSource %s", makeContainerSourceOIDCServiceAccountWithoutOwnerRef().Name, sourceName)),
-					WithContainerSourceOIDCServiceAccountName(makeContainerSourceOIDCServiceAccountWithoutOwnerRef().Name),
-				),
-			}},
-			WantEvents: []string{
-				Eventf(corev1.EventTypeWarning, "InternalError", fmt.Sprintf("service account %s not owned by ContainerSource %s", makeContainerSourceOIDCServiceAccountWithoutOwnerRef().Name, sourceName)),
-			},
 		},
 	}
 
@@ -324,7 +240,6 @@ func TestAllCases(t *testing.T) {
 			containerSourceLister:      listers.GetContainerSourceLister(),
 			deploymentLister:           listers.GetDeploymentLister(),
 			sinkBindingLister:          listers.GetSinkBindingLister(),
-			serviceAccountLister:       listers.GetServiceAccountLister(),
 			trustBundleConfigMapLister: listers.GetConfigMapLister(),
 		}
 		return containersource.NewReconciler(ctx, logging.FromContext(ctx), fakeeventingclient.Get(ctx), listers.GetContainerSourceLister(), controller.GetEventRecorder(ctx), r)
@@ -446,18 +361,4 @@ func makeSinkBindingStatus(ready *corev1.ConditionStatus) *sourcesv1.SinkBinding
 			},
 		},
 	}
-}
-
-func makeContainerSourceOIDCServiceAccount() *corev1.ServiceAccount {
-	return auth.GetOIDCServiceAccountForResource(sourcesv1.SchemeGroupVersion.WithKind("ContainerSource"), metav1.ObjectMeta{
-		Name:      sourceName,
-		Namespace: testNS,
-		UID:       sourceUID,
-	})
-}
-
-func makeContainerSourceOIDCServiceAccountWithoutOwnerRef() *corev1.ServiceAccount {
-	sa := makeContainerSourceOIDCServiceAccount()
-	sa.OwnerReferences = nil
-	return sa
 }

--- a/pkg/reconciler/containersource/controller.go
+++ b/pkg/reconciler/containersource/controller.go
@@ -23,22 +23,20 @@ import (
 	configmapinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap/filtered"
 	"knative.dev/pkg/system"
 
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	deploymentinformer "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+
 	"knative.dev/eventing/pkg/apis/feature"
 	v1 "knative.dev/eventing/pkg/apis/sources/v1"
-	"knative.dev/eventing/pkg/auth"
 	eventingclient "knative.dev/eventing/pkg/client/injection/client"
 	containersourceinformer "knative.dev/eventing/pkg/client/injection/informers/sources/v1/containersource"
 	sinkbindinginformer "knative.dev/eventing/pkg/client/injection/informers/sources/v1/sinkbinding"
 	v1containersource "knative.dev/eventing/pkg/client/injection/reconciler/sources/v1/containersource"
 	"knative.dev/eventing/pkg/eventingtls"
 	eventingreconciler "knative.dev/eventing/pkg/reconciler"
-
-	kubeclient "knative.dev/pkg/client/injection/kube/client"
-	deploymentinformer "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
-	serviceaccountinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/filtered"
-	"knative.dev/pkg/configmap"
-	"knative.dev/pkg/controller"
-	"knative.dev/pkg/logging"
 )
 
 // NewController creates a Reconciler for ContainerSource and returns the result of NewImpl.
@@ -52,7 +50,6 @@ func NewController(
 	containersourceInformer := containersourceinformer.Get(ctx)
 	sinkbindingInformer := sinkbindinginformer.Get(ctx)
 	deploymentInformer := deploymentinformer.Get(ctx)
-	oidcServiceaccountInformer := serviceaccountinformer.Get(ctx, auth.OIDCLabelSelector)
 	trustBundleConfigMapInformer := configmapinformer.Get(ctx, eventingtls.TrustBundleLabelSelector)
 
 	var globalResync func(obj interface{})
@@ -70,7 +67,6 @@ func NewController(
 		containerSourceLister:      containersourceInformer.Lister(),
 		deploymentLister:           deploymentInformer.Lister(),
 		sinkBindingLister:          sinkbindingInformer.Lister(),
-		serviceAccountLister:       oidcServiceaccountInformer.Lister(),
 		trustBundleConfigMapLister: trustBundleConfigMapInformer.Lister(),
 	}
 	impl := v1containersource.NewImpl(ctx, r, func(impl *controller.Impl) controller.Options {

--- a/pkg/reconciler/containersource/controller_test.go
+++ b/pkg/reconciler/containersource/controller_test.go
@@ -22,19 +22,18 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/eventing/pkg/auth"
 	filteredFactory "knative.dev/pkg/client/injection/kube/informers/factory/filtered"
 	"knative.dev/pkg/configmap"
 	. "knative.dev/pkg/reconciler/testing"
 
 	// Fake injection informers
+	"knative.dev/eventing/pkg/apis/feature"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap/filtered/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/filtered/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/factory/filtered/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
 
-	"knative.dev/eventing/pkg/apis/feature"
 	_ "knative.dev/eventing/pkg/client/injection/informers/sources/v1/containersource/fake"
 	_ "knative.dev/eventing/pkg/client/injection/informers/sources/v1/sinkbinding/fake"
 	"knative.dev/eventing/pkg/eventingtls"
@@ -57,6 +56,6 @@ func TestNew(t *testing.T) {
 }
 
 func SetUpInformerSelector(ctx context.Context) context.Context {
-	ctx = filteredFactory.WithSelectors(ctx, auth.OIDCLabelSelector, eventingtls.TrustBundleLabelSelector)
+	ctx = filteredFactory.WithSelectors(ctx, eventingtls.TrustBundleLabelSelector)
 	return ctx
 }

--- a/pkg/reconciler/testing/v1/containersource.go
+++ b/pkg/reconciler/testing/v1/containersource.go
@@ -18,11 +18,10 @@ package testing
 
 import (
 	"context"
-	"fmt"
 
-	"knative.dev/eventing/pkg/apis/feature"
-	v1 "knative.dev/eventing/pkg/apis/sources/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	v1 "knative.dev/eventing/pkg/apis/sources/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -93,24 +92,6 @@ func WithContainerUnobservedGeneration() ContainerSourceOption {
 		condSet := c.GetConditionSet()
 		condSet.Manage(&c.Status).MarkUnknown(
 			condSet.GetTopLevelConditionType(), "NewObservedGenFailure", "unsuccessfully observed a new generation")
-	}
-}
-
-func WithContainerSourceOIDCIdentityCreatedSucceeded() ContainerSourceOption {
-	return func(c *v1.ContainerSource) {
-		c.Status.MarkOIDCIdentityCreatedSucceeded()
-	}
-}
-
-func WithContainerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled() ContainerSourceOption {
-	return func(c *v1.ContainerSource) {
-		c.Status.MarkOIDCIdentityCreatedSucceededWithReason(fmt.Sprintf("%s feature disabled", feature.OIDCAuthentication), "")
-	}
-}
-
-func WithContainerSourceOIDCIdentityCreatedFailed(reason, message string) ContainerSourceOption {
-	return func(c *v1.ContainerSource) {
-		c.Status.MarkOIDCIdentityCreatedFailed(reason, message)
 	}
 }
 


### PR DESCRIPTION
Backporting changes from https://github.com/knative/eventing/pull/7890/files (without e2e tests, as they require a reconciler-test update)