### PR TITLE
Increase timeout for REKT tests to 90m

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -123,7 +123,7 @@ function run_e2e_rekt_tests(){
       local run_command="-run ^(${test_name})$"
   fi
   # check for test flags
-  RUN_FLAGS="-timeout=1h -parallel=20"
+  RUN_FLAGS="-timeout=90m -parallel=20"
   if [ -n "${EVENTING_TEST_FLAGS:-}" ]; then
     RUN_FLAGS="${EVENTING_TEST_FLAGS}"
   fi


### PR DESCRIPTION
The execution might take longer if the client is run farther away from the cluster (i.e. not in the same cloud).

/cherry-pick release-v1.14
/cherry-pick main

Slack [discussion](https://redhat-internal.slack.com/archives/CLUCMK7R6/p1716281254912199)