### PR TITLE
Add Konflux custom build pipeline for eventing-controller

### DIFF
--- a/.tekton/knative-eventing-controller-pull-request.yaml
+++ b/.tekton/knative-eventing-controller-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/creydr/knative-eventing?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift-knative/eventing?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
@@ -15,7 +15,7 @@ metadata:
     appstudio.openshift.io/component: knative-eventing-controller
     pipelines.appstudio.openshift.io/type: build
   name: knative-eventing-controller-on-pull-request
-  namespace: cstabler-tenant
+  namespace: ocp-serverless-tenant
 spec:
   params:
   - name: dockerfile
@@ -25,7 +25,7 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: output-image
-    value: quay.io/redhat-user-workloads/cstabler-tenant/serverless-operator-konflux/knative-eventing-controller:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-konflux/knative-eventing-controller:on-pr-{{revision}}
   - name: path-context
     value: .
   - name: revision

--- a/.tekton/knative-eventing-controller-push.yaml
+++ b/.tekton/knative-eventing-controller-push.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/creydr/knative-eventing?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift-knative/eventing?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
@@ -14,7 +14,7 @@ metadata:
     appstudio.openshift.io/component: knative-eventing-controller
     pipelines.appstudio.openshift.io/type: build
   name: knative-eventing-controller-on-push
-  namespace: cstabler-tenant
+  namespace: ocp-serverless-tenant
 spec:
   params:
   - name: dockerfile
@@ -22,7 +22,7 @@ spec:
   - name: git-url
     value: '{{source_url}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cstabler-tenant/serverless-operator-konflux/knative-eventing-controller:{{revision}}
+    value: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-konflux/knative-eventing-controller:{{revision}}
   - name: path-context
     value: .
   - name: revision


### PR DESCRIPTION
Custom build pipelines [seems to be needed](https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1715797686219869?thread_ts=1715687993.964879&cid=C04PZ7H0VA8) to enable to nudging / renovate job PRs