### PR TITLE
Enable debug logging in generate.sh

### DIFF
--- a/openshift/generate.sh
+++ b/openshift/generate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -xeuo pipefail
 
 repo_root_dir=$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..
 
@@ -12,3 +12,5 @@ $(go env GOPATH)/bin/generate \
   --root-dir "${repo_root_dir}" \
   --generators dockerfile \
   --dockerfile-image-builder-fmt "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-%s-openshift-4.16"
+
+set +x


### PR DESCRIPTION
Enable debug logging to debug current issues in generate.sh (e.g. https://master-jenkins-csb-serverless-qe.apps.ocp-c1.prod.psi.redhat.com/job/ci/job/knative-nightly-ci-eventing/1233/console)