### PR TITLE
Use OCP 4.17 based image in generate to support Go 1.22

### DIFF
--- a/openshift/generate.sh
+++ b/openshift/generate.sh
@@ -16,4 +16,4 @@ rm -rf "$tmp_dir"
 $(go env GOPATH)/bin/generate \
   --root-dir "${repo_root_dir}" \
   --generators dockerfile \
-  --dockerfile-image-builder-fmt "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-%s-openshift-4.16"
+  --dockerfile-image-builder-fmt "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-%s-openshift-4.17"


### PR DESCRIPTION
`registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.16` does not exist. See https://github.com/openshift-knative/eventing/pull/623#issuecomment-2194117272

 So switching to OCP 4.17 based image to have Golang 1.22.

Similar to openshift-knative/serving/pull/750