### PR TITLE
[release-v1.14] EventType tests verify the type under spec.reference

### DIFF
--- a/test/experimental/features/eventtype_autocreate/features.go
+++ b/test/experimental/features/eventtype_autocreate/features.go
@@ -136,7 +136,9 @@ func AutoCreateEventTypesOnBroker(brokerName string) *feature.Feature {
 		Must("deliver events to subscriber", assert.OnStore(sink).MatchEvent(cetest.HasId(event.ID())).AtLeast(1)).
 		Must("create event type", eventtype.WaitForEventType(
 			eventtype.AssertReady(expectedTypes),
-			eventtype.AssertExactPresent(expectedTypes)))
+			eventtype.AssertExactPresent(expectedTypes),
+			eventtype.AssertReferencePresent(broker.AsKReference(brokerName))),
+		)
 
 	return f
 }
@@ -215,7 +217,8 @@ func AutoCreateEventTypeEventsFromPingSource() *feature.Feature {
 			cetest.HasType(sourcesv1.PingSourceEventType)).AtLeast(1)).
 		Must("PingSource test eventtypes match", eventtype.WaitForEventType(
 			eventtype.AssertReady(expectedCeTypes),
-			eventtype.AssertPresent(expectedCeTypes)))
+			eventtype.AssertPresent(expectedCeTypes),
+			eventtype.AssertReferencePresent(broker.AsKReference(brokerName))))
 
 	return f
 }

--- a/test/rekt/features/pingsource/features.go
+++ b/test/rekt/features/pingsource/features.go
@@ -227,7 +227,8 @@ func SendsEventsWithEventTypes() *feature.Feature {
 			test.HasType("dev.knative.sources.ping")).AtLeast(1)).
 		Must("PingSource test eventtypes match", eventtype.WaitForEventType(
 			eventtype.AssertReady(expectedCeTypes),
-			eventtype.AssertPresent(expectedCeTypes)))
+			eventtype.AssertPresent(expectedCeTypes),
+			eventtype.AssertReferencePresent(broker.AsKReference(brokerName))))
 
 	return f
 }


### PR DESCRIPTION
Backport changes from release-v1.15 and allow stricter verification already for 1.14 midstream.

Related to verifying https://issues.redhat.com/browse/SRVKE-1503