### PR TITLE
[release-v1.14] backport Assert EventTypes references for IMC test (#7899)

### DIFF
--- a/test/experimental/eventtype_autocreate_test.go
+++ b/test/experimental/eventtype_autocreate_test.go
@@ -102,17 +102,3 @@ func TestPingSourceEventTypeMatch(t *testing.T) {
 
 	env.Test(ctx, t, eventtype_autocreate.AutoCreateEventTypeEventsFromPingSource())
 }
-
-func TestContainerSourceEventTypeAutoCreate(t *testing.T) {
-	t.Parallel()
-
-	ctx, env := global.Environment(
-		knative.WithKnativeNamespace(system.Namespace()),
-		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
-		k8s.WithEventListener,
-		environment.Managed(t),
-	)
-
-	env.Test(ctx, t, eventtype_autocreate.AutoCreateEventTypesOnContainerSource())
-}


### PR DESCRIPTION
Backports https://github.com/knative/eventing/pull/7899 

* Assert EventTypes references for IMC and ContainerSource test
* Do not use ID as the attribute to match the event
The id is different for each event when using container source. Use just the type, like other tests for container source.
* Fix type
* Remove test for ContainerSource EventType creation
It is not supported.