### PR TITLE
[release-v1.14] fix downstream build go toolchain error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module knative.dev/eventing
 
 go 1.22
 
+toolchain go1.22.5
+
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.1-0.20210420163308-c1402a70e2f1
 	github.com/cloudevents/conformance v0.2.0


### PR DESCRIPTION
at brew build it fails to download a go toolchain because it fails to identify which one to download.

cc @matzew @pierDipi 