### PR TITLE
[release-v1.15] Bump to latest upstream reconciler-test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	knative.dev/hack v0.0.0-20240704013904-b9799599afcf
 	knative.dev/hack/schema v0.0.0-20240704013904-b9799599afcf
 	knative.dev/pkg v0.0.0-20240716082220-4355f0c73608
-	knative.dev/reconciler-test v0.0.0-20240924090532-7ce3eca90b55
+	knative.dev/reconciler-test v0.0.0-20240927070509-8fa68bab4e6e
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -844,8 +844,8 @@ knative.dev/hack/schema v0.0.0-20240704013904-b9799599afcf h1:AUfdS2IxgjNLc7jplP
 knative.dev/hack/schema v0.0.0-20240704013904-b9799599afcf/go.mod h1:3pWwBLnTZSM9psSgCAvhKOHIPTzqfEMlWRpDu6IYhK0=
 knative.dev/pkg v0.0.0-20240716082220-4355f0c73608 h1:BOiRzcnRS9Z5ruxlCiS/K1/Hb5bUN0X4W3xCegdcYQE=
 knative.dev/pkg v0.0.0-20240716082220-4355f0c73608/go.mod h1:M67lDZ4KbltYSon0Ox4/6qjlZNOIXW4Ldequ81yofbw=
-knative.dev/reconciler-test v0.0.0-20240924090532-7ce3eca90b55 h1:5oNAuT0m6g092con5K6SB2r1cAjrMjvLwN0ntTH25JE=
-knative.dev/reconciler-test v0.0.0-20240924090532-7ce3eca90b55/go.mod h1:SxsgIk8gq6brVnQfKqCKOTtgmjXinZe2dqnsx3XeAvo=
+knative.dev/reconciler-test v0.0.0-20240927070509-8fa68bab4e6e h1:dKvlFOerbODOqf33e+gnsYLD7JeX3CJooquff8j8vgQ=
+knative.dev/reconciler-test v0.0.0-20240927070509-8fa68bab4e6e/go.mod h1:SxsgIk8gq6brVnQfKqCKOTtgmjXinZe2dqnsx3XeAvo=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/vendor/knative.dev/reconciler-test/pkg/eventshub/103-pod.yaml
+++ b/vendor/knative.dev/reconciler-test/pkg/eventshub/103-pod.yaml
@@ -19,6 +19,9 @@ metadata:
   namespace: {{ .namespace }}
   labels:
     app: eventshub-{{ .name }}
+    {{ range $key, $value := .labels }}
+    {{ $key }}: "{{ $value }}"
+    {{ end }}
   {{ if .annotations }}
   annotations:
     {{ range $key, $value := .annotations }}

--- a/vendor/knative.dev/reconciler-test/pkg/eventshub/104-forwarder.yaml
+++ b/vendor/knative.dev/reconciler-test/pkg/eventshub/104-forwarder.yaml
@@ -25,12 +25,20 @@ metadata:
   {{ end }}
 spec:
   template:
-    {{ if .podannotations }}
+    {{ if or .podannotations .podlabels }}
     metadata:
+      {{ if .podannotations }}
       annotations:
         {{ range $key, $value := .podannotations }}
           {{ $key }}: "{{ $value }}"
-          {{ end }}
+        {{ end }}
+      {{ end }}
+      {{ if .podlabels }}
+      labels:
+        {{ range $key, $value := .podlabels }}
+          {{ $key }}: "{{ $value }}"
+        {{ end }}
+      {{ end }}
     {{ end }}
     spec:
       serviceAccountName: "{{ .name }}"

--- a/vendor/knative.dev/reconciler-test/pkg/eventshub/resources.go
+++ b/vendor/knative.dev/reconciler-test/pkg/eventshub/resources.go
@@ -165,6 +165,7 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
 
 		if ic := environment.GetIstioConfig(ctx); ic.Enabled {
 			manifest.WithIstioPodAnnotations(cfg)
+			manifest.WithIstioPodLabels(cfg)
 		}
 
 		manifest.PodSecurityCfgFn(ctx, t)(cfg)

--- a/vendor/knative.dev/reconciler-test/pkg/manifest/options.go
+++ b/vendor/knative.dev/reconciler-test/pkg/manifest/options.go
@@ -63,6 +63,21 @@ func WithPodAnnotations(additional map[string]interface{}) CfgFn {
 	}
 }
 
+// WithPodLabels appends pod labels (usually used by types where pod template is embedded)
+func WithPodLabels(additional map[string]string) CfgFn {
+	return func(cfg map[string]interface{}) {
+		if ann, ok := cfg["podlabels"]; ok {
+			m := make(map[string]interface{}, len(additional))
+			for k, v := range additional {
+				m[k] = v
+			}
+			appendToOriginal(ann, m)
+			return
+		}
+		cfg["podlabels"] = additional
+	}
+}
+
 func appendToOriginal(original interface{}, additional map[string]interface{}) {
 	annotations := original.(map[string]interface{})
 	for k, v := range additional {
@@ -91,4 +106,13 @@ func WithIstioPodAnnotations(cfg map[string]interface{}) {
 
 	WithAnnotations(podAnnotations)(cfg)
 	WithPodAnnotations(podAnnotations)(cfg)
+}
+
+func WithIstioPodLabels(cfg map[string]interface{}) {
+	podLabels := map[string]string{
+		"sidecar.istio.io/inject": "true",
+	}
+
+	WithLabels(podLabels)(cfg)
+	WithPodLabels(podLabels)(cfg)
 }

--- a/vendor/knative.dev/reconciler-test/pkg/resources/cronjob/cronjob.go
+++ b/vendor/knative.dev/reconciler-test/pkg/resources/cronjob/cronjob.go
@@ -62,6 +62,7 @@ func Install(name string, image string, options ...manifest.CfgFn) feature.StepF
 
 		if ic := environment.GetIstioConfig(ctx); ic.Enabled {
 			manifest.WithIstioPodAnnotations(cfg)
+			manifest.WithIstioPodLabels(cfg)
 		}
 
 		manifest.PodSecurityCfgFn(ctx, t)(cfg)

--- a/vendor/knative.dev/reconciler-test/pkg/resources/deployment/deployment.go
+++ b/vendor/knative.dev/reconciler-test/pkg/resources/deployment/deployment.go
@@ -49,6 +49,7 @@ func Install(name string, image string, options ...manifest.CfgFn) feature.StepF
 
 		if ic := environment.GetIstioConfig(ctx); ic.Enabled {
 			manifest.WithIstioPodAnnotations(cfg)
+			manifest.WithIstioPodLabels(cfg)
 		}
 
 		manifest.PodSecurityCfgFn(ctx, t)(cfg)

--- a/vendor/knative.dev/reconciler-test/pkg/resources/deployment/deployment.yaml
+++ b/vendor/knative.dev/reconciler-test/pkg/resources/deployment/deployment.yaml
@@ -36,6 +36,9 @@ spec:
         {{ range $key, $value := .selectors }}
         {{ $key }}: "{{ $value }}"
         {{ end }}
+        {{ range $key, $value := .podlabels }}
+        {{ $key }}: "{{ $value }}"
+        {{ end }}
     spec:
       {{ if .podSecurityContext }}
       securityContext:

--- a/vendor/knative.dev/reconciler-test/pkg/resources/job/job.go
+++ b/vendor/knative.dev/reconciler-test/pkg/resources/job/job.go
@@ -47,6 +47,7 @@ func Install(name string, image string, options ...manifest.CfgFn) feature.StepF
 
 		if ic := environment.GetIstioConfig(ctx); ic.Enabled {
 			manifest.WithIstioPodAnnotations(cfg)
+			manifest.WithIstioPodLabels(cfg)
 		}
 
 		manifest.PodSecurityCfgFn(ctx, t)(cfg)

--- a/vendor/knative.dev/reconciler-test/pkg/resources/pod/pod.go
+++ b/vendor/knative.dev/reconciler-test/pkg/resources/pod/pod.go
@@ -44,6 +44,7 @@ func Install(name string, image string, opts ...manifest.CfgFn) feature.StepFn {
 
 		if ic := environment.GetIstioConfig(ctx); ic.Enabled {
 			manifest.WithIstioPodAnnotations(cfg)
+			manifest.WithIstioPodLabels(cfg)
 		}
 
 		manifest.PodSecurityCfgFn(ctx, t)(cfg)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1205,7 +1205,7 @@ knative.dev/pkg/webhook/resourcesemantics
 knative.dev/pkg/webhook/resourcesemantics/conversion
 knative.dev/pkg/webhook/resourcesemantics/defaulting
 knative.dev/pkg/webhook/resourcesemantics/validation
-# knative.dev/reconciler-test v0.0.0-20240924090532-7ce3eca90b55
+# knative.dev/reconciler-test v0.0.0-20240927070509-8fa68bab4e6e
 ## explicit; go 1.22
 knative.dev/reconciler-test/cmd/eventshub
 knative.dev/reconciler-test/pkg/environment


### PR DESCRIPTION
updated `go.mod` to pin to latest from upstream 1.15

ran `make generate-release` to consume the updated reconciler test.

However, afterwards I also had to manually apply these two patches:

```
git apply openshift/patches/020-mutemetrics.patch && git apply openshift/patches/027-rekt-serviceaccounts-delete.patch
```

Not sure why they are ignored:
https://github.com/openshift-knative/eventing/blob/release-v1.15/openshift/release/generate-release.sh#L15-L16
