### PR TITLE
[release-v1.15] Add observedGeneration in JobSink OpenAPI schema 

### DIFF
--- a/config/core/resources/jobsink.yaml
+++ b/config/core/resources/jobsink.yaml
@@ -94,6 +94,10 @@ spec:
                       name:
                         description: The name of the applied EventPolicy
                         type: string
+                observedGeneration:
+                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                  type: integer
+                  format: int64
                 conditions:
                   description: Conditions the latest available observations of a resource's current state.
                   type: array

--- a/openshift/release/artifacts/eventing-core.yaml
+++ b/openshift/release/artifacts/eventing-core.yaml
@@ -3392,6 +3392,10 @@ spec:
                       name:
                         description: The name of the applied EventPolicy
                         type: string
+                observedGeneration:
+                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                  type: integer
+                  format: int64
                 conditions:
                   description: Conditions the latest available observations of a resource's current state.
                   type: array

--- a/openshift/release/artifacts/eventing-crds.yaml
+++ b/openshift/release/artifacts/eventing-crds.yaml
@@ -1758,6 +1758,10 @@ spec:
                       name:
                         description: The name of the applied EventPolicy
                         type: string
+                observedGeneration:
+                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                  type: integer
+                  format: int64
                 conditions:
                   description: Conditions the latest available observations of a resource's current state.
                   type: array

--- a/pkg/reconciler/jobsink/jobsink_test.go
+++ b/pkg/reconciler/jobsink/jobsink_test.go
@@ -28,10 +28,6 @@ import (
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/utils/ptr"
-	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
-	jobsinkreconciler "knative.dev/eventing/pkg/client/injection/reconciler/sinks/v1alpha1/jobsink"
-	. "knative.dev/eventing/pkg/reconciler/testing/v1"
-	. "knative.dev/eventing/pkg/reconciler/testing/v1alpha1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	v1 "knative.dev/pkg/client/injection/ducks/duck/v1/addressable"
@@ -40,6 +36,12 @@ import (
 	logtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/network"
 	. "knative.dev/pkg/reconciler/testing"
+
+	"knative.dev/eventing/pkg/apis/sinks/v1alpha1"
+	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
+	jobsinkreconciler "knative.dev/eventing/pkg/client/injection/reconciler/sinks/v1alpha1/jobsink"
+	. "knative.dev/eventing/pkg/reconciler/testing/v1"
+	. "knative.dev/eventing/pkg/reconciler/testing/v1alpha1"
 )
 
 const (
@@ -195,6 +197,36 @@ func TestReconcile(t *testing.T) {
 						WithJobSinkEventPoliciesNotReady("EventPoliciesNotReady", fmt.Sprintf("event policies %s are not ready", unreadyEventPolicyName)),
 						WithJobSinkEventPoliciesListed(readyEventPolicyName),
 					),
+				},
+			},
+		},
+		{
+			Name: "Successful reconciliation, observed generation",
+			Key:  testKey,
+			Objects: []runtime.Object{
+				NewJobSink(jobSinkName, testNamespace,
+					func(sink *v1alpha1.JobSink) {
+						sink.Generation = 4242
+					},
+					WithJobSinkJob(testJob("")),
+					WithInitJobSinkConditions),
+			},
+			WantErr: false,
+			WantCreates: []runtime.Object{
+				testJob("test-jobSinkml6mm"),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{
+				{
+					Object: NewJobSink(jobSinkName, testNamespace,
+						WithJobSinkJob(testJob("")),
+						WithJobSinkAddressableReady(),
+						WithJobSinkJobStatusSelector(),
+						WithJobSinkAddress(&jobSinkAddressable),
+						func(sink *v1alpha1.JobSink) {
+							sink.Generation = 4242
+							sink.Status.ObservedGeneration = 4242
+						},
+						WithJobSinkEventPoliciesReadyBecauseOIDCDisabled()),
 				},
 			},
 		},


### PR DESCRIPTION
Backport of https://github.com/knative/eventing/pull/8297