### PR TITLE
Add jobsinks-addressable-resolver cluster role

### DIFF
--- a/config/core/roles/addressable-resolvers-clusterrole.yaml
+++ b/config/core/roles/addressable-resolvers-clusterrole.yaml
@@ -144,3 +144,25 @@ rules:
   - get
   - list
   - watch
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: jobsinks-addressable-resolver
+  labels:
+    duck.knative.dev/addressable: "true"
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
+# Do not use this role directly. These rules will be added to the "addressable-resolver" role.
+rules:
+- apiGroups:
+    - sinks.knative.dev
+  resources:
+    - jobsinks
+    - jobsinks/status
+  verbs:
+    - get
+    - list
+    - watch


### PR DESCRIPTION
Backport from upstream.

This will ensure that alld ServiceAccount that are bound to "addressable-resolver" ClusterRole can read JobSinks.

Fixes issues like this for SinkBindings:
```
{"level":"error","ts":"2024-11-04T08:06:16.160Z","logger":"eventing-webhook","caller":"sinkbinding/sinkbinding.go:87",
"msg":"Failed to get Addressable from Destination:
%!w(*fmt.wrapError=&{failed to get lister for
sinks.knative.dev/v1alpha1,
Resource=jobsinks: jobsinks.sinks.knative.dev is forbidden:
User \"system:serviceaccount:knative-eventing:eventing-webhook\"
cannot list resource \"jobsinks\" in API group \"sinks.knative.dev\"
```