### PR TITLE
[release-v1.15] Remove conversion webhook config in EventPolicy CRD

### DIFF
--- a/config/core/resources/eventpolicy.yaml
+++ b/config/core/resources/eventpolicy.yaml
@@ -171,11 +171,3 @@ spec:
       - knative
       - eventing
   scope: Namespaced
-  conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions: ["v1", "v1beta1"]
-      clientConfig:
-        service:
-          name: eventing-webhook
-          namespace: knative-eventing

--- a/openshift/release/artifacts/eventing-core.yaml
+++ b/openshift/release/artifacts/eventing-core.yaml
@@ -2863,14 +2863,6 @@ spec:
       - knative
       - eventing
   scope: Namespaced
-  conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions: ["v1", "v1beta1"]
-      clientConfig:
-        service:
-          name: eventing-webhook
-          namespace: knative-eventing
 ---
 # Copyright 2020 The Knative Authors
 #

--- a/openshift/release/artifacts/eventing-crds.yaml
+++ b/openshift/release/artifacts/eventing-crds.yaml
@@ -1207,14 +1207,6 @@ spec:
       - knative
       - eventing
   scope: Namespaced
-  conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions: ["v1", "v1beta1"]
-      clientConfig:
-        service:
-          name: eventing-webhook
-          namespace: knative-eventing
 ---
 # Copyright 2020 The Knative Authors
 #


### PR DESCRIPTION
As we don't have multiple EventPolicy versions yet, we don't need the conversion webhook configuration in the EventPolicy CRD.

Cherry-pick of https://github.com/knative/eventing/pull/8379/files

/cherry-pick release-v1.16