### PR TITLE
[release-v1.15] Register eventshub image for JobSink

### DIFF
--- a/test/rekt/resources/jobsink/jobsink.go
+++ b/test/rekt/resources/jobsink/jobsink.go
@@ -70,6 +70,9 @@ func Install(name string, opts ...manifest.CfgFn) feature.StepFn {
 			fn(cfg)
 		}
 
+		if err := registerImage(ctx); err != nil {
+			t.Fatal(err)
+		}
 		if _, err := manifest.InstallYamlFS(ctx, yamlEmbed, cfg); err != nil {
 			t.Fatal(err)
 		}
@@ -202,4 +205,11 @@ func AsKReference(name string) *duckv1.KReference {
 		Name:       name,
 		APIVersion: GVR().GroupVersion().String(),
 	}
+}
+
+func registerImage(ctx context.Context) error {
+	im := eventshub.ImageFromContext(ctx)
+	reg := environment.RegisterPackage(im)
+	_, err := reg(ctx, environment.FromContext(ctx))
+	return err
 }


### PR DESCRIPTION
The package must be registered so that ImageProducer can map it to the right image and replace it in the final yaml.

Backport from upstream.
This test was failing on ARM64 where the timing was slightly different.