### PR TITLE
[release-v1.16] Add health check config and clean up duplicated code (#8308)

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -20,12 +20,6 @@ import (
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
 	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
-	"errors"
-	"log"
-	"net/http"
-	"os"
-	"time"
-
 	"knative.dev/pkg/injection/sharedmain"
 
 	filteredFactory "knative.dev/pkg/client/injection/kube/informers/factory/filtered"
@@ -51,35 +45,7 @@ import (
 )
 
 func main() {
-
 	ctx := signals.NewContext()
-
-	port := os.Getenv("PROBES_PORT")
-	if port == "" {
-		port = "8080"
-	}
-
-	// sets up liveness and readiness probes.
-	server := http.Server{
-		ReadTimeout: 5 * time.Second,
-		Handler:     http.HandlerFunc(handler),
-		Addr:        ":" + port,
-	}
-
-	go func() {
-
-		go func() {
-			<-ctx.Done()
-			_ = server.Shutdown(ctx)
-		}()
-
-		// start the web server on port and accept requests
-		log.Printf("Readiness and health check server listening on port %s", port)
-
-		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			log.Fatal(err)
-		}
-	}()
 
 	ctx = filteredFactory.WithSelectors(ctx,
 		auth.OIDCLabelSelector,
@@ -114,8 +80,4 @@ func main() {
 		sugarnamespace.NewController,
 		sugartrigger.NewController,
 	)
-}
-
-func handler(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusOK)
 }

--- a/config/brokers/mt-channel-broker/deployments/controller.yaml
+++ b/config/brokers/mt-channel-broker/deployments/controller.yaml
@@ -81,8 +81,27 @@ spec:
             drop:
             - ALL
 
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: probes
+            scheme: HTTP
+          initialDelaySeconds: 20
+          periodSeconds: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: probes
+            scheme: HTTP
+          initialDelaySeconds: 20
+          periodSeconds: 10
+          timeoutSeconds: 5
+
         ports:
         - name: metrics
           containerPort: 9090
         - name: profiling
           containerPort: 8008
+        - name: probes
+          containerPort: 8080

--- a/config/core/deployments/pingsource-mt-adapter.yaml
+++ b/config/core/deployments/pingsource-mt-adapter.yaml
@@ -87,6 +87,8 @@ spec:
             - containerPort: 9090
               name: metrics
               protocol: TCP
+            - name: probes
+              containerPort: 8080
           resources:
             requests:
               cpu: 125m
@@ -101,5 +103,22 @@ spec:
             capabilities:
               drop:
               - ALL
+
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: probes
+              scheme: HTTP
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: probes
+              scheme: HTTP
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
 
       serviceAccountName: pingsource-mt-adapter

--- a/openshift/release/artifacts/eventing-core.yaml
+++ b/openshift/release/artifacts/eventing-core.yaml
@@ -6506,6 +6506,8 @@ spec:
             - containerPort: 9090
               name: metrics
               protocol: TCP
+            - name: probes
+              containerPort: 8080
           resources:
             requests:
               cpu: 125m
@@ -6520,6 +6522,23 @@ spec:
             capabilities:
               drop:
               - ALL
+
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: probes
+              scheme: HTTP
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: probes
+              scheme: HTTP
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
 
       serviceAccountName: pingsource-mt-adapter
 ---

--- a/openshift/release/artifacts/mt-channel-broker.yaml
+++ b/openshift/release/artifacts/mt-channel-broker.yaml
@@ -799,11 +799,30 @@ spec:
             drop:
             - ALL
 
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: probes
+            scheme: HTTP
+          initialDelaySeconds: 20
+          periodSeconds: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: probes
+            scheme: HTTP
+          initialDelaySeconds: 20
+          periodSeconds: 10
+          timeoutSeconds: 5
+
         ports:
         - name: metrics
           containerPort: 9090
         - name: profiling
           containerPort: 8008
+        - name: probes
+          containerPort: 8080
 ---
 # Copyright 2020 The Knative Authors
 #

--- a/pkg/adapter/apiserver/adapter.go
+++ b/pkg/adapter/apiserver/adapter.go
@@ -19,7 +19,6 @@ package apiserver
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -126,20 +125,8 @@ func (a *apiServerAdapter) start(ctx context.Context, stopCh <-chan struct{}) er
 		}
 	}
 
-	srv := &http.Server{
-		Addr: ":8080",
-		// Configure read header timeout to overcome potential Slowloris Attack because ReadHeaderTimeout is not
-		// configured in the http.Server.
-		ReadHeaderTimeout: 10 * time.Second,
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-		}),
-	}
-	go srv.ListenAndServe()
-
 	<-stopCh
 	stop <- struct{}{}
-	srv.Shutdown(ctx)
 	return nil
 }
 

--- a/pkg/adapter/v2/context.go
+++ b/pkg/adapter/v2/context.go
@@ -124,3 +124,14 @@ func ConfiguratorOptionsFromContext(ctx context.Context) []ConfiguratorOption {
 	}
 	return value.([]ConfiguratorOption)
 }
+
+type healthProbesDisabledKey struct{}
+
+// WithHealthProbesDisabled signals to MainWithContext that it should disable default probes (readiness and liveness).
+func WithHealthProbesDisabled(ctx context.Context) context.Context {
+	return context.WithValue(ctx, healthProbesDisabledKey{}, struct{}{})
+}
+
+func HealthProbesDisabled(ctx context.Context) bool {
+	return ctx.Value(healthProbesDisabledKey{}) != nil
+}

--- a/pkg/adapter/v2/main.go
+++ b/pkg/adapter/v2/main.go
@@ -306,6 +306,14 @@ func MainWithInformers(ctx context.Context, component string, env EnvConfigAcces
 		}()
 	}
 
+	if !HealthProbesDisabled(ctx) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			injection.ServeHealthProbes(ctx, injection.HealthCheckDefaultPort)
+		}()
+	}
+
 	// Finally start the adapter (blocking)
 	if err := adapter.Start(ctx); err != nil {
 		logger.Fatalw("Start returned an error", zap.Error(err))

--- a/pkg/adapter/v2/main_test.go
+++ b/pkg/adapter/v2/main_test.go
@@ -67,6 +67,7 @@ func TestMainWithContext(t *testing.T) {
 	}()
 
 	ctx := context.TODO()
+	ctx = WithHealthProbesDisabled(ctx)
 	ctx, _ = fakekubeclient.With(ctx)
 
 	MainWithContext(ctx, "mycomponent",

--- a/pkg/reconciler/apiserversource/resources/receive_adapter.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter.go
@@ -96,13 +96,22 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) (*appsv1.Deployment, error) {
 								Name:          "metrics",
 								ContainerPort: 9090,
 							}, {
-								Name:          "health",
+								Name:          "probes",
 								ContainerPort: 8080,
 							}},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
-										Port: intstr.FromString("health"),
+										Path: "readiness",
+										Port: intstr.FromString("probes"),
+									},
+								},
+							},
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "health",
+										Port: intstr.FromString("probes"),
 									},
 								},
 							},

--- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
@@ -144,7 +144,7 @@ O2dgzikq8iSy1BlRsVw=
 								Name:          "metrics",
 								ContainerPort: 9090,
 							}, {
-								Name:          "health",
+								Name:          "probes",
 								ContainerPort: 8080,
 							}},
 							Env: []corev1.EnvVar{
@@ -187,7 +187,16 @@ O2dgzikq8iSy1BlRsVw=
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
-										Port: intstr.FromString("health"),
+										Port: intstr.FromString("probes"),
+										Path: "readiness",
+									},
+								},
+							},
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Port: intstr.FromString("probes"),
+										Path: "health",
 									},
 								},
 							},


### PR DESCRIPTION
Backport of https://github.com/knative/eventing/commit/7c1a62de528314e0488c7cb47b59a1939071e469 to fix current eventing-istio[ failures with release-next CI](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-knative_eventing-istio/334/pull-ci-openshift-knative-eventing-istio-release-next-417-e2e-tests/1886955655865044992) (see https://redhat-internal.slack.com/archives/GT8P6G5U0/p1738681070042699)