### PR TITLE
Run hack generate tool directly

### DIFF
--- a/openshift/generate.sh
+++ b/openshift/generate.sh
@@ -4,16 +4,7 @@ set -euo pipefail
 
 repo_root_dir=$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..
 
-tmp_dir=$(mktemp -d)
-git clone --branch main https://github.com/openshift-knative/hack "$tmp_dir"
-
-pushd "$tmp_dir"
-go install github.com/openshift-knative/hack/cmd/generate
-popd
-
-rm -rf "$tmp_dir"
-
-$(go env GOPATH)/bin/generate \
+GOFLAGS='' go run github.com/openshift-knative/hack/cmd/generate@latest \
   --root-dir "${repo_root_dir}" \
   --generators dockerfile \
   --additional-packages tzdata \


### PR DESCRIPTION
Fixing current issues with installing hack tools

```
Cloning into '/tmp/hack'...
+ cd /tmp/hack
+ go install github.com/openshift-knative/hack/cmd/generate
go: inconsistent vendoring in /tmp/hack:
...
```