### PR TITLE
[release-v1.16] SinkBinding: Set specific conditions for reconciler steps

### DIFF
--- a/pkg/apis/sources/v1/sinkbinding_lifecycle.go
+++ b/pkg/apis/sources/v1/sinkbinding_lifecycle.go
@@ -42,9 +42,11 @@ const (
 )
 
 var sbCondSet = apis.NewLivingConditionSet(
+	SinkBindingConditionAvailable,
 	SinkBindingConditionSinkProvided,
 	SinkBindingConditionOIDCIdentityCreated,
 	SinkBindingConditionOIDCTokenSecretCreated,
+	SinkBindingTrustBundlePropagated,
 )
 
 // GetConditionSet retrieves the condition set for this resource. Implements the KRShaped interface.
@@ -86,12 +88,23 @@ func (sbs *SinkBindingStatus) InitializeConditions() {
 // MarkBindingUnavailable marks the SinkBinding's Ready condition to False with
 // the provided reason and message.
 func (sbs *SinkBindingStatus) MarkBindingUnavailable(reason, message string) {
-	sbCondSet.Manage(sbs).MarkFalse(SinkBindingConditionReady, reason, message)
+	sbCondSet.Manage(sbs).MarkFalse(SinkBindingConditionAvailable, reason, message)
 }
 
 // MarkBindingAvailable marks the SinkBinding's Ready condition to True.
 func (sbs *SinkBindingStatus) MarkBindingAvailable() {
-	sbCondSet.Manage(sbs).MarkTrue(SinkBindingConditionReady)
+	sbCondSet.Manage(sbs).MarkTrue(SinkBindingConditionAvailable)
+}
+
+// MarkFailedTrustBundlePropagation marks the SinkBinding's SinkBindingTrustBundlePropagated condition to False with
+// the provided reason and message.
+func (sbs *SinkBindingStatus) MarkFailedTrustBundlePropagation(reason, message string) {
+	sbCondSet.Manage(sbs).MarkFalse(SinkBindingTrustBundlePropagated, reason, message)
+}
+
+// MarkTrustBundlePropagated marks the SinkBinding's SinkBindingTrustBundlePropagated condition to True.
+func (sbs *SinkBindingStatus) MarkTrustBundlePropagated() {
+	sbCondSet.Manage(sbs).MarkTrue(SinkBindingTrustBundlePropagated)
 }
 
 // MarkSink sets the condition that the source has a sink configured.
@@ -104,6 +117,11 @@ func (sbs *SinkBindingStatus) MarkSink(addr *duckv1.Addressable) {
 	} else {
 		sbCondSet.Manage(sbs).MarkFalse(SinkBindingConditionSinkProvided, "SinkEmpty", "Sink has resolved to empty.%s", "")
 	}
+}
+
+// MarkSinkFailed sets the condition that the source has a sink configured.
+func (sbs *SinkBindingStatus) MarkSinkFailed(reason, messageFormat string, messageA ...interface{}) {
+	sbCondSet.Manage(sbs).MarkFalse(SinkBindingConditionSinkProvided, reason, messageFormat, messageA...)
 }
 
 func (sbs *SinkBindingStatus) MarkOIDCIdentityCreatedSucceeded() {

--- a/pkg/apis/sources/v1/sinkbinding_lifecycle_test.go
+++ b/pkg/apis/sources/v1/sinkbinding_lifecycle_test.go
@@ -165,6 +165,7 @@ func TestSinkBindingStatusIsReady(t *testing.T) {
 			s := &SinkBindingStatus{}
 			s.InitializeConditions()
 			s.MarkSink(sink)
+			s.MarkTrustBundlePropagated()
 			s.MarkBindingUnavailable("TheReason", "this is the message")
 			return s
 		}(),
@@ -175,6 +176,7 @@ func TestSinkBindingStatusIsReady(t *testing.T) {
 			s := &SinkBindingStatus{}
 			s.InitializeConditions()
 			s.MarkSink(sink)
+			s.MarkTrustBundlePropagated()
 			s.MarkBindingAvailable()
 			s.MarkOIDCIdentityCreatedSucceeded()
 			s.MarkOIDCTokenSecretCreatedSuccceeded()
@@ -187,6 +189,7 @@ func TestSinkBindingStatusIsReady(t *testing.T) {
 			s := &SinkBindingStatus{}
 			s.InitializeConditions()
 			s.MarkSink(sink)
+			s.MarkTrustBundlePropagated()
 			s.MarkBindingAvailable()
 			s.MarkOIDCIdentityCreatedSucceeded()
 			s.MarkOIDCTokenSecretCreatedSuccceeded()
@@ -199,6 +202,7 @@ func TestSinkBindingStatusIsReady(t *testing.T) {
 			s := &SinkBindingStatus{}
 			s.InitializeConditions()
 			s.MarkSink(sink)
+			s.MarkTrustBundlePropagated()
 			s.MarkBindingAvailable()
 			s.MarkOIDCIdentityCreatedSucceededWithReason("TheReason", "feature is disabled")
 			s.MarkOIDCTokenSecretCreatedSuccceeded()
@@ -211,6 +215,7 @@ func TestSinkBindingStatusIsReady(t *testing.T) {
 			s := &SinkBindingStatus{}
 			s.InitializeConditions()
 			s.MarkSink(sink)
+			s.MarkTrustBundlePropagated()
 			s.MarkBindingAvailable()
 			s.MarkOIDCIdentityCreatedFailed("TheReason", "this is a message")
 			s.MarkOIDCTokenSecretCreatedSuccceeded()
@@ -223,6 +228,7 @@ func TestSinkBindingStatusIsReady(t *testing.T) {
 			s := &SinkBindingStatus{}
 			s.InitializeConditions()
 			s.MarkSink(sink)
+			s.MarkTrustBundlePropagated()
 			s.MarkBindingAvailable()
 			s.MarkOIDCIdentityCreatedSucceeded()
 			s.MarkOIDCTokenSecretCreatedSuccceeded()
@@ -235,9 +241,23 @@ func TestSinkBindingStatusIsReady(t *testing.T) {
 			s := &SinkBindingStatus{}
 			s.InitializeConditions()
 			s.MarkSink(sink)
+			s.MarkTrustBundlePropagated()
 			s.MarkBindingAvailable()
 			s.MarkOIDCIdentityCreatedSucceeded()
 			s.MarkOIDCTokenSecretCreatedFailed("Some", "reason")
+			return s
+		}(),
+		want: false,
+	}, {
+		name: "mark trust bundle propagation failed",
+		s: func() *SinkBindingStatus {
+			s := &SinkBindingStatus{}
+			s.InitializeConditions()
+			s.MarkSink(sink)
+			s.MarkFailedTrustBundlePropagation("failed", "failed")
+			s.MarkBindingAvailable()
+			s.MarkOIDCIdentityCreatedSucceeded()
+			s.MarkOIDCTokenSecretCreatedSuccceeded()
 			return s
 		}(),
 		want: false,
@@ -974,5 +994,19 @@ func TestSinkBindingDoNoURI(t *testing.T) {
 
 	if !cmp.Equal(got, want) {
 		t.Error("Undo (-want, +got):", cmp.Diff(want, got))
+	}
+}
+
+func TestSinkBindingUnavailable(t *testing.T) {
+
+	sb := &SinkBinding{}
+	sb.Status.InitializeConditions()
+	sb.Status.MarkBindingUnavailable("failed", "failed")
+
+	sb.Status.InitializeConditions()
+
+	r := sb.Status.GetCondition(apis.ConditionReady)
+	if r.IsTrue() || r.IsUnknown() {
+		t.Error("unexpected condition: ", r)
 	}
 }

--- a/pkg/apis/sources/v1/sinkbinding_types.go
+++ b/pkg/apis/sources/v1/sinkbinding_types.go
@@ -70,13 +70,17 @@ type SinkBindingSpec struct {
 }
 
 const (
-	// SinkBindingConditionReady is configured to indicate whether the Binding
+	// SinkBindingConditionAvailable is configured to indicate whether the Binding
 	// has been configured for resources subject to its runtime contract.
-	SinkBindingConditionReady = apis.ConditionReady
+	SinkBindingConditionAvailable apis.ConditionType = "SinkBindingAvailable"
 
 	// SinkBindingConditionSinkProvided is configured to indicate whether the
 	// sink has been properly extracted from the resolver.
 	SinkBindingConditionSinkProvided apis.ConditionType = "SinkProvided"
+
+	// SinkBindingTrustBundlePropagated is configured to indicate whether the
+	// TLS trust bundle has been properly propagated.
+	SinkBindingTrustBundlePropagated apis.ConditionType = "TrustBundlePropagated"
 
 	// SinkBindingConditionOIDCIdentityCreated is configured to indicate whether
 	// the OIDC identity has been created for the sink.


### PR DESCRIPTION
Instead of setting the ready condition during reconciliation steps, set specific conditions since the ready condition is managed and set according to the state of other conditions.

Cherry-pick of https://github.com/knative/eventing/pull/8508/commits/45905c755ae74ea3899416df87cec201b0a309cf