### PR TITLE
Bump OCP version to 4.19 for builder image

### DIFF
--- a/openshift/generate.sh
+++ b/openshift/generate.sh
@@ -8,4 +8,4 @@ GOFLAGS='' go run github.com/openshift-knative/hack/cmd/generate@latest \
   --root-dir "${repo_root_dir}" \
   --generators dockerfile \
   --additional-packages tzdata \
-  --dockerfile-image-builder-fmt "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-%s-openshift-4.17"
+  --dockerfile-image-builder-fmt "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-%s-openshift-4.19"


### PR DESCRIPTION
Seeing 
```
error: build error: failed to pull image: After retrying 2 times, Pull image still failed due to error: initializing source docker://registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.23-openshift-4.17: reading manifest rhel-8-release-golang-1.23-openshift-4.17 in registry.ci.openshift.org/openshift/release: manifest unknown
```
in [CI 1896361615167590400](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-knative_eventing/1121/pull-ci-openshift-knative-eventing-release-next-417-test-reconciler/1896361615167590400) in https://github.com/openshift-knative/eventing/pull/1121

So bumping the OCP version to an image, which has golang 1.23