### PR TITLE
[release-v1.15] If no subscriber uri is present we return 404, instead of 400

### DIFF
--- a/pkg/broker/filter/filter_handler.go
+++ b/pkg/broker/filter/filter_handler.go
@@ -399,8 +399,8 @@ func (h *Handler) handleDispatchToSubscriberRequest(ctx context.Context, trigger
 	subscriberURI := trigger.Status.SubscriberURI
 	if subscriberURI == nil {
 		// Record the event count.
-		writer.WriteHeader(http.StatusBadRequest)
-		_ = h.reporter.ReportEventCount(reportArgs, http.StatusBadRequest)
+		writer.WriteHeader(http.StatusNotFound)
+		_ = h.reporter.ReportEventCount(reportArgs, http.StatusNotFound)
 		return
 	}
 

--- a/pkg/broker/filter/filter_handler_test.go
+++ b/pkg/broker/filter/filter_handler_test.go
@@ -126,7 +126,7 @@ func TestReceiver(t *testing.T) {
 			triggers: []*eventingv1.Trigger{
 				makeTrigger(withoutSubscriberURI()),
 			},
-			expectedStatus:     http.StatusBadRequest,
+			expectedStatus:     http.StatusNotFound,
 			expectedEventCount: true,
 		},
 		"Trigger without a Filter": {


### PR DESCRIPTION
If no subscriber uri is present we return 404, instead of 400 which means the request from the client itself would have had isssues

Is backport from upstream