### PR TITLE
Add branch name as prefix to renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "enabledManagers": ["tekton"],
+  "commitMessagePrefix": "[{{branchName}}]",
   "ignorePaths": [
     ".konflux-release/**",
     "third_party/**",


### PR DESCRIPTION
Test to add the branch name as a prefix to the Mintmaker/renovate PRs (https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1742845632536849?thread_ts=1742816609.437959&cid=C04PZ7H0VA8), eg on PRs like this #1258

We need this on the main branch to test it. Will be included in the hack repo, when this works as expected