### PR TITLE
[release-v1.16] rename `job-sink` to `job_sink` (#8335)

### DIFF
--- a/cmd/jobsink/main.go
+++ b/cmd/jobsink/main.go
@@ -66,7 +66,7 @@ import (
 	"knative.dev/eventing/pkg/utils"
 )
 
-const component = "job-sink"
+const component = "job_sink"
 
 func main() {
 


### PR DESCRIPTION
backport to 1.16 