### PR TITLE
Test renovate branch prefix 2

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,8 @@
     "third_party/**",
     "vendor/**",
     "**/images-rekt.yaml"
+  ],
+  "labels": [
+    "skip-review"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "enabledManagers": ["tekton"],
-  "commitMessagePrefix": "[{{branchName}}]",
+  "commitMessagePrefix": "[{{baseBranch}}]",
   "ignorePaths": [
     ".konflux-release/**",
     "third_party/**",


### PR DESCRIPTION
Similar to #1281, but now uses the `baseBranch` as PR prefix (otherwise it results in PR titles like `[konflux/references/release-v1.17] Update Konflux references`) and adds the `skip-review` label.

We need this on the main branch to test it. Will be included in the hack repo, when this works as expected