### PR TITLE
[release-v1.16] Check for Auth.ServiceAccountName when the OIDC feature flag is switched on to avoid potential nil

### DIFF
--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
@@ -240,7 +240,7 @@ func newConfigForInMemoryChannel(ctx context.Context, imc *v1.InMemoryChannel) (
 		}
 
 		conf.Namespace = imc.Namespace
-		if isOIDCEnabled {
+		if isOIDCEnabled && sub.Auth != nil && sub.Auth.ServiceAccountName != nil {
 			conf.ServiceAccount = &types.NamespacedName{
 				Name:      *sub.Auth.ServiceAccountName,
 				Namespace: imc.Namespace,


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/SRVKE-1610 