### PR TITLE
[release-v1.17] Adding addressable duck on crd && run make generate release

### DIFF
--- a/config/core/resources/eventtransform.yaml
+++ b/config/core/resources/eventtransform.yaml
@@ -18,6 +18,7 @@ metadata:
   name: eventtransforms.eventing.knative.dev
   labels:
     knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 spec:

--- a/openshift/release/artifacts/eventing-core.yaml
+++ b/openshift/release/artifacts/eventing-core.yaml
@@ -3041,6 +3041,7 @@ metadata:
   name: eventtransforms.eventing.knative.dev
   labels:
     knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: v1.17
     app.kubernetes.io/name: knative-eventing
 spec:

--- a/openshift/release/artifacts/eventing-crds.yaml
+++ b/openshift/release/artifacts/eventing-crds.yaml
@@ -1266,6 +1266,7 @@ metadata:
   name: eventtransforms.eventing.knative.dev
   labels:
     knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: v1.17
     app.kubernetes.io/name: knative-eventing
 spec:


### PR DESCRIPTION
Backport of https://github.com/knative/eventing/pull/8603
and running `make generate-release` afterwards 