### PR TITLE
Fix: Remove stats_reporter.go patch from generate-release.sh too

### DIFF
--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -12,7 +12,6 @@ release=${release/knative-/}
 echo "Release: $release"
 
 "${root_dir}"/hack/update-codegen.sh
-git apply "${root_dir}"/openshift/patches/020-mutemetrics.patch
 git apply "${root_dir}"/openshift/patches/027-rekt-serviceaccounts-delete.patch
 
 ./openshift/generate.sh


### PR DESCRIPTION
Missed to clean it up in #1471 