### PR TITLE
Add auth-proxy to image replaces

### DIFF
--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -33,6 +33,7 @@ function resolve_resources(){
         -e "s+knative.dev/eventing/cmd/ping+${image_prefix}ping${image_tag}+" \
         -e "s+knative.dev/eventing/cmd/mtping+${image_prefix}mtping${image_tag}+" \
         -e "s+knative.dev/eventing/cmd/apiserver_receive_adapter+${image_prefix}apiserver-receive-adapter${image_tag}+" \
+        -e "s+knative.dev/eventing/cmd/auth_proxy+${image_prefix}auth-proxy${image_tag}+" \
         -e "s+\(.* image: \)\(knative.dev\)\(.*/\)\(.*\)+\1${image_prefix}\4${image_tag}+g" \
         "$yaml" >> "$resolved_file_name"
   done


### PR DESCRIPTION
This will lead to having the correct image reference in the controller, like:

```
          - name: AUTH_PROXY_IMAGE
            value: registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-auth-proxy
```

And helps to fix the image pull issues like in #1580 ([here](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-knative_eventing/1580/pull-ci-openshift-knative-eventing-release-next-419-test-encryption-auth-e2e/1969929398366769152)) after the auth-proxy gets built in konflux (after 1.20 is in midstream)