### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for kn-eventing-ingress-115

### DIFF
--- a/openshift/ci-operator/knative-images/ingress/Dockerfile
+++ b/openshift/ci-operator/knative-images/ingress/Dockerfile
@@ -24,8 +24,9 @@ USER 65532
 
 LABEL \
       com.redhat.component="openshift-serverless-1-eventing-broker-ingress-rhel8-container" \
-      name="openshift-serverless-1/eventing-broker-ingress-rhel8" \
+      name="openshift-serverless-1/kn-eventing-ingress-rhel8" \
       version=$VERSION \
+      cpe="cpe:/a:redhat:openshift_serverless:1.35::el8" \
       summary="Red Hat OpenShift Serverless 1 Eventing Broker Ingress" \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Eventing Broker Ingress" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
