### PR TITLE
[release-v1.21] Fix ApiServerSource metrics port to 9092 (#8895)

### DIFF
--- a/pkg/reconciler/apiserversource/resources/receive_adapter.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter.go
@@ -95,7 +95,7 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) (*appsv1.Deployment, error) {
 							Env:   env,
 							Ports: []corev1.ContainerPort{{
 								Name:          "metrics",
-								ContainerPort: 9090,
+								ContainerPort: 9092,
 							}, {
 								Name:          "probes",
 								ContainerPort: 8080,

--- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
@@ -141,7 +141,7 @@ O2dgzikq8iSy1BlRsVw=
 							Image: "test-image",
 							Ports: []corev1.ContainerPort{{
 								Name:          "metrics",
-								ContainerPort: 9090,
+								ContainerPort: 9092,
 							}, {
 								Name:          "probes",
 								ContainerPort: 8080,


### PR DESCRIPTION
Cherry-pick of https://github.com/knative/eventing/pull/8895/changes