### PR TITLE
[release-v1.21] sinkbinding and trustbundle backports

### DIFF
--- a/pkg/apis/sources/v1/sinkbinding_lifecycle.go
+++ b/pkg/apis/sources/v1/sinkbinding_lifecycle.go
@@ -262,12 +262,14 @@ func (sb *SinkBinding) Do(ctx context.Context, ps *duckv1.WithPod) {
 			ps.Spec.Template.Spec.Containers[i].VolumeMounts = append(ps.Spec.Template.Spec.Containers[i].VolumeMounts, corev1.VolumeMount{
 				Name:      oidcTokenVolumeName,
 				MountPath: "/oidc",
+				ReadOnly:  true,
 			})
 		}
 		for i := range ps.Spec.Template.Spec.InitContainers {
 			ps.Spec.Template.Spec.InitContainers[i].VolumeMounts = append(ps.Spec.Template.Spec.InitContainers[i].VolumeMounts, corev1.VolumeMount{
 				Name:      oidcTokenVolumeName,
 				MountPath: "/oidc",
+				ReadOnly:  true,
 			})
 		}
 	}

--- a/pkg/apis/sources/v1/sinkbinding_lifecycle_test.go
+++ b/pkg/apis/sources/v1/sinkbinding_lifecycle_test.go
@@ -874,6 +874,7 @@ func TestSinkBindingDo(t *testing.T) {
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      oidcTokenVolumeName,
 								MountPath: "/oidc",
+								ReadOnly:  true,
 							}},
 						}},
 						Containers: []corev1.Container{{
@@ -892,6 +893,7 @@ func TestSinkBindingDo(t *testing.T) {
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      oidcTokenVolumeName,
 								MountPath: "/oidc",
+								ReadOnly:  true,
 							}},
 						}},
 						Volumes: []corev1.Volume{{

--- a/pkg/eventingtls/trust_bundle.go
+++ b/pkg/eventingtls/trust_bundle.go
@@ -190,7 +190,8 @@ func PropagateTrustBundles(ctx context.Context, k8s kubernetes.Interface, trustB
 
 		if !equality.Semantic.DeepDerivative(expected.Data, p.userCm.Data) ||
 			!equality.Semantic.DeepDerivative(expected.BinaryData, p.userCm.BinaryData) ||
-			!equality.Semantic.DeepDerivative(expected.Labels, p.userCm.Labels) {
+			!equality.Semantic.DeepDerivative(expected.Labels, p.userCm.Labels) ||
+			!equality.Semantic.DeepDerivative(expected.OwnerReferences, p.userCm.OwnerReferences) {
 			if err := updateConfigMap(ctx, k8s, expected); err != nil {
 				return nil, err
 			}
@@ -309,7 +310,14 @@ func AddTrustBundleVolumesFromConfigMaps(cms []*corev1.ConfigMap, pt *corev1.Pod
 }
 
 func combineValidTrustBundles(configMaps []*corev1.ConfigMap, combinedBundle *bytes.Buffer) error {
-	for _, cm := range configMaps {
+	// Create a sorted copy of configMaps to ensure consistent ordering without modifying the input slice
+	sortedCMs := make([]*corev1.ConfigMap, len(configMaps))
+	copy(sortedCMs, configMaps)
+	sort.SliceStable(sortedCMs, func(i, j int) bool {
+		return sortedCMs[i].Name < sortedCMs[j].Name
+	})
+
+	for _, cm := range sortedCMs {
 
 		// Ensure the combined bundle is always composed in the same order.
 		keys := make([]string, 0, len(cm.Data))

--- a/pkg/eventingtls/trust_bundle_test.go
+++ b/pkg/eventingtls/trust_bundle_test.go
@@ -24,13 +24,34 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
-	"strings"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// parseCertsFromPEM parses all certificates from PEM-encoded data
+func parseCertsFromPEM(t *testing.T, pemData []byte) []*x509.Certificate {
+	var certs []*x509.Certificate
+	remaining := pemData
+	for len(remaining) > 0 {
+		var block *pem.Block
+		block, remaining = pem.Decode(remaining)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			t.Fatalf("Failed to parse certificate: %v", err)
+		}
+		certs = append(certs, cert)
+	}
+	return certs
+}
 
 func TestCombineValidTrustBundles(t *testing.T) {
 	// Helper function to create a valid test certificate
@@ -146,6 +167,31 @@ MIIDIzCC corrupted certificate data
 			expectError: false,
 		},
 		{
+			name: "Multiple ConfigMaps in reversed order produces consistent output",
+			configMaps: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cm2",
+						Namespace: "test",
+					},
+					Data: map[string]string{
+						"cert2.pem": string(validCert2),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cm1",
+						Namespace: "test",
+					},
+					Data: map[string]string{
+						"cert1.pem": string(validCert1),
+					},
+				},
+			},
+			expected:    string(validCert1) + string(validCert2),
+			expectError: false,
+		},
+		{
 			name: "Multiple certificates in same key",
 			configMaps: []*corev1.ConfigMap{
 				{
@@ -179,7 +225,8 @@ MIIDIzCC corrupted certificate data
 					},
 				},
 			},
-			expected:    string(validCert1) + string(validCert2) + string(validCert3),
+			// We expect the certs in the alphabetical order of the keys
+			expected:    string(validCert3) + string(validCert1) + string(validCert2),
 			expectError: false,
 		},
 		{
@@ -217,36 +264,26 @@ MIIDIzCC corrupted certificate data
 				t.Errorf("Did not expect error but got: %v", err)
 			}
 
-			// For valid certs, we need to compare the actual content
-			// by counting the number of certificates
+			// For valid certs, verify the actual content and order
 			if !tt.expectError {
-				result := buf.String()
+				result := buf.Bytes()
+				expected := []byte(tt.expected)
 
-				expectedCertCount := strings.Count(tt.expected, "BEGIN CERTIFICATE")
-				resultCertCount := strings.Count(result, "BEGIN CERTIFICATE")
+				// Parse expected certificates
+				expectedCerts := parseCertsFromPEM(t, expected)
+				// Parse result certificates
+				resultCerts := parseCertsFromPEM(t, result)
 
-				if expectedCertCount != resultCertCount {
+				// Check count
+				if len(expectedCerts) != len(resultCerts) {
 					t.Errorf("Expected %d certificates, got %d",
-						expectedCertCount, resultCertCount)
+						len(expectedCerts), len(resultCerts))
 				}
 
-				// Verify the actual certificates are there
-				// We can't compare the exact string due to PEM encoding variations
-				// so we count and check if each cert was included
-				remainingPEM := []byte(result)
-				for i := 0; i < expectedCertCount; i++ {
-					var block *pem.Block
-					block, remainingPEM = pem.Decode(remainingPEM)
-
-					if block == nil {
-						t.Errorf("Failed to decode PEM block %d", i)
-						break
-					}
-
-					// Verify it's a valid certificate
-					_, err := x509.ParseCertificate(block.Bytes)
-					if err != nil {
-						t.Errorf("PEM block %d is not a valid certificate: %v", i, err)
+				// Check order and equality
+				for i := 0; i < len(expectedCerts) && i < len(resultCerts); i++ {
+					if !expectedCerts[i].Equal(resultCerts[i]) {
+						t.Errorf("Certificate at index %d does not match expected certificate", i)
 					}
 				}
 			}


### PR DESCRIPTION
Backports sinkbinding-related fixes from upstream , related to SRVKE-1580 

Both of these issues together causing unnecessary updates to resources when sinkbindings with oidc and/or transport-security is involved.

https://github.com/knative/eventing/pull/8894 make sinkbinding oidc-token volume mount readOnly#8894
https://github.com/knative/eventing/pull/8899 consistent order for the combined trust bundle#8899