### PR TITLE
[DNM][testonly][release-v1.21] revert trustbundle propagation in sinkbinding lifecycle Do

### DIFF
--- a/pkg/apis/sources/v1/sinkbinding_lifecycle.go
+++ b/pkg/apis/sources/v1/sinkbinding_lifecycle.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	"go.uber.org/zap"
-	"k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -215,30 +214,13 @@ func (sb *SinkBinding) Do(ctx context.Context, ps *duckv1.WithPod) {
 			Value: ceOverrides,
 		})
 	}
-	gvk := schema.GroupVersionKind{
-		Group:   SchemeGroupVersion.Group,
-		Version: SchemeGroupVersion.Version,
-		Kind:    "SinkBinding",
-	}
-	bundles, err := eventingtls.PropagateTrustBundles(ctx, getKubeClient(ctx), GetTrustBundleConfigMapLister(ctx), gvk, sb)
+
+	pss, err := eventingtls.AddTrustBundleVolumes(GetTrustBundleConfigMapLister(ctx), sb, &ps.Spec.Template.Spec)
 	if err != nil {
-		logging.FromContext(ctx).Errorw("Failed to propagate trust bundles", zap.Error(err))
+		logging.FromContext(ctx).Errorw("Failed to add trust bundle volumes %s/%s: %+v", zap.Error(err))
+		return
 	}
-	if len(bundles) > 0 {
-		pss, err := eventingtls.AddTrustBundleVolumesFromConfigMaps(bundles, &ps.Spec.Template.Spec)
-		if err != nil {
-			logging.FromContext(ctx).Errorw("Failed to add trust bundle volumes from configmaps %s/%s: %+v", zap.Error(err))
-			return
-		}
-		ps.Spec.Template.Spec = *pss
-	} else {
-		pss, err := eventingtls.AddTrustBundleVolumes(GetTrustBundleConfigMapLister(ctx), sb, &ps.Spec.Template.Spec)
-		if err != nil {
-			logging.FromContext(ctx).Errorw("Failed to add trust bundle volumes %s/%s: %+v", zap.Error(err))
-			return
-		}
-		ps.Spec.Template.Spec = *pss
-	}
+	ps.Spec.Template.Spec = *pss
 
 	if sb.Status.OIDCTokenSecretName != nil {
 		ps.Spec.Template.Spec.Volumes = append(ps.Spec.Template.Spec.Volumes, corev1.Volume{
@@ -346,20 +328,6 @@ func (sb *SinkBinding) Undo(ctx context.Context, ps *duckv1.WithPod) {
 		}
 		ps.Spec.Template.Spec.Volumes = volumes
 	}
-}
-
-type kubeClientKey struct{}
-
-func WithKubeClient(ctx context.Context, k kubernetes.Interface) context.Context {
-	return context.WithValue(ctx, kubeClientKey{}, k)
-}
-
-func getKubeClient(ctx context.Context) kubernetes.Interface {
-	k := ctx.Value(kubeClientKey{})
-	if k == nil {
-		panic("No Kube client found in context.")
-	}
-	return k.(kubernetes.Interface)
 }
 
 type configMapListerKey struct{}

--- a/pkg/apis/sources/v1/sinkbinding_lifecycle_test.go
+++ b/pkg/apis/sources/v1/sinkbinding_lifecycle_test.go
@@ -32,7 +32,6 @@ import (
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/client/injection/ducks/duck/v1/addressable"
-	kubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	configmapinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap/fake"
 	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
 	"knative.dev/pkg/resolver"
@@ -929,7 +928,6 @@ func TestSinkBindingDo(t *testing.T) {
 			}
 			ctx = WithURIResolver(ctx, r)
 			ctx = WithTrustBundleConfigMapLister(ctx, configmapinformer.Get(ctx).Lister())
-			ctx = WithKubeClient(ctx, kubeclient.Get(ctx))
 
 			for _, cm := range test.configMaps {
 				_ = configmapinformer.Get(ctx).Informer().GetIndexer().Add(cm)

--- a/pkg/reconciler/sinkbinding/controller.go
+++ b/pkg/reconciler/sinkbinding/controller.go
@@ -150,9 +150,8 @@ func NewController(
 		trustBundleConfigMapLister: trustBundleConfigMapLister,
 	}
 
-	k8s := kubeclient.Get(ctx)
 	c.WithContext = func(ctx context.Context, b psbinding.Bindable) (context.Context, error) {
-		return v1.WithKubeClient(v1.WithTrustBundleConfigMapLister(v1.WithURIResolver(ctx, sbResolver), trustBundleConfigMapLister), k8s), nil
+		return v1.WithTrustBundleConfigMapLister(v1.WithURIResolver(ctx, sbResolver), trustBundleConfigMapLister), nil
 	}
 	c.Tracker = impl.Tracker
 	c.Factory = &duck.CachedInformerFactory{
@@ -226,10 +225,9 @@ func ListAll(ctx context.Context, handler cache.ResourceEventHandler) psbinding.
 
 func WithContextFactory(ctx context.Context, lister corev1listers.ConfigMapLister, handler func(types.NamespacedName)) psbinding.BindableContext {
 	r := resolver.NewURIResolverFromTracker(ctx, tracker.New(handler, controller.GetTrackerLease(ctx)))
-	k := kubeclient.Get(ctx)
 
 	return func(ctx context.Context, b psbinding.Bindable) (context.Context, error) {
-		return v1.WithKubeClient(v1.WithTrustBundleConfigMapLister(v1.WithURIResolver(ctx, r), lister), k), nil
+		return v1.WithTrustBundleConfigMapLister(v1.WithURIResolver(ctx, r), lister), nil
 	}
 }
 


### PR DESCRIPTION
Testonly, see if we can pass tests without the trustbundle propagation in sinkbinding `Do`

The `PropagateTrustBundles` invocation in Do causes readiness/liveness failured in the eventing-webhook in jobsink scenarios, as it gets/updates trustbundle CMs _per each resource_ bound by sinkbinding (which, for use cases such as sinkbinding-bound jobsink jobs is a lot of resources... )

(the trustbundle propagation in Do was introduced in https://github.com/knative/eventing/pull/7726/changes/f88d983fbf5e83525ccf1858975d0d24b9ea73f1 )