### PR TITLE
[WIP] Add configurable metric attributes deny list

### DIFF
--- a/config/core/configmaps/observability.yaml
+++ b/config/core/configmaps/observability.yaml
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
   annotations:
-    knative.dev/example-checksum: "0270bb17"
+    knative.dev/example-checksum: "023c9567"
 data:
   _example: |
     ################################
@@ -57,6 +57,11 @@ data:
     # metrics-export-interval specifies the global metrics reporting period for control and data plane components.
     # If a zero or negative value is passed the default reporting OTel period is used (60 secs).
     metrics-export-interval: 60s
+
+    # metrics-attributes-deny is a comma-separated list of metric attribute keys to filter
+    # out from all metrics. This can help prevent OOM issues caused by unbounded
+    # metric cardinality in production (e.g. cloudevents.type, messaging.destination.name).
+    metrics-attributes-deny: ""
 
     # sink-event-error-reporting.enable whether the adapter reports a kube event to the CRD indicating
     # a failure to send a cloud event to the sink.

--- a/openshift/patches/028-metrics-attributes-deny.patch
+++ b/openshift/patches/028-metrics-attributes-deny.patch
@@ -1,0 +1,113 @@
+diff --git a/vendor/knative.dev/pkg/injection/sharedmain/main.go b/vendor/knative.dev/pkg/injection/sharedmain/main.go
+index 50d5f4c79..a44fde056 100644
+--- a/vendor/knative.dev/pkg/injection/sharedmain/main.go
++++ b/vendor/knative.dev/pkg/injection/sharedmain/main.go
+@@ -399,10 +399,15 @@ func SetupObservabilityOrDie(
+ 
+ 	resource := resource.Default(component)
+ 
++	views := OTelViews(ctx)
++	if denyList := cfg.Metrics.AttributesDenyList(); len(denyList) > 0 {
++		views = append(views, metrics.MetricAttributesDenyFilter(denyList))
++	}
++
+ 	meterProvider, err := metrics.NewMeterProvider(
+ 		ctx,
+ 		cfg.Metrics,
+-		metric.WithView(OTelViews(ctx)...),
++		metric.WithView(views...),
+ 		metric.WithResource(resource),
+ 	)
+ 	if err != nil {
+diff --git a/vendor/knative.dev/pkg/observability/metrics/config.go b/vendor/knative.dev/pkg/observability/metrics/config.go
+index dc911c2e6..6cb742aa8 100644
+--- a/vendor/knative.dev/pkg/observability/metrics/config.go
++++ b/vendor/knative.dev/pkg/observability/metrics/config.go
+@@ -18,6 +18,7 @@ package metrics
+ 
+ import (
+ 	"fmt"
++	"strings"
+ 	"time"
+ 
+ 	configmap "knative.dev/pkg/configmap/parser"
+@@ -38,6 +39,28 @@ type Config struct {
+ 	Protocol       string        `json:"protocol,omitempty"`
+ 	Endpoint       string        `json:"endpoint,omitempty"`
+ 	ExportInterval time.Duration `json:"exportInterval,omitempty"`
++
++	// AttributesDeny is a comma-separated list of metric attribute keys to
++	// filter out from all instruments (e.g. "cloudevents.type,messaging.destination.name").
++	// Stored as a string rather than []string to keep Config comparable,
++	// which is relied upon by downstream consumers. Use AttributesDenyList()
++	// to get the parsed list.
++	AttributesDeny string `json:"attributesDeny,omitempty"`
++}
++
++// AttributesDenyList returns the deny list parsed into individual keys.
++func (c *Config) AttributesDenyList() []string {
++	if c.AttributesDeny == "" {
++		return nil
++	}
++	parts := strings.Split(c.AttributesDeny, ",")
++	result := make([]string, 0, len(parts))
++	for _, p := range parts {
++		if t := strings.TrimSpace(p); t != "" {
++			result = append(result, t)
++		}
++	}
++	return result
+ }
+ 
+ func (c *Config) Validate() error {
+@@ -79,6 +102,7 @@ func NewFromMapWithPrefix(prefix string, m map[string]string) (Config, error) {
+ 	c := DefaultConfig()
+ 
+ 	err := configmap.Parse(m,
++		configmap.As(prefix+"metrics-attributes-deny", &c.AttributesDeny),
+ 		configmap.As(prefix+"metrics-protocol", &c.Protocol),
+ 		configmap.As(prefix+"metrics-endpoint", &c.Endpoint),
+ 		configmap.As(prefix+"metrics-export-interval", &c.ExportInterval),
+diff --git a/vendor/knative.dev/pkg/observability/metrics/view.go b/vendor/knative.dev/pkg/observability/metrics/view.go
+new file mode 100644
+index 000000000..00406e126
+--- /dev/null
++++ b/vendor/knative.dev/pkg/observability/metrics/view.go
+@@ -0,0 +1,37 @@
++/*
++Copyright 2026 The Knative Authors
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package metrics
++
++import (
++	"go.opentelemetry.io/otel/attribute"
++	"go.opentelemetry.io/otel/sdk/metric"
++)
++
++// MetricAttributesDenyFilter returns a View that strips the given attribute
++// keys from every instrument.
++func MetricAttributesDenyFilter(denyList []string) metric.View {
++	keys := make([]attribute.Key, len(denyList))
++	for i, k := range denyList {
++		keys[i] = attribute.Key(k)
++	}
++	return metric.NewView(
++		metric.Instrument{Name: "*"},
++		metric.Stream{
++			AttributeFilter: attribute.NewDenyKeysFilter(keys...),
++		},
++	)
++}

--- a/openshift/release/artifacts/eventing-core.yaml
+++ b/openshift/release/artifacts/eventing-core.yaml
@@ -8663,7 +8663,7 @@ metadata:
     app.kubernetes.io/version: v1.21
     app.kubernetes.io/name: knative-eventing
   annotations:
-    knative.dev/example-checksum: "0270bb17"
+    knative.dev/example-checksum: "023c9567"
 data:
   _example: |
     ################################
@@ -8697,6 +8697,11 @@ data:
     # metrics-export-interval specifies the global metrics reporting period for control and data plane components.
     # If a zero or negative value is passed the default reporting OTel period is used (60 secs).
     metrics-export-interval: 60s
+
+    # metrics-attributes-deny is a comma-separated list of metric attribute keys to filter
+    # out from all metrics. This can help prevent OOM issues caused by unbounded
+    # metric cardinality in production (e.g. cloudevents.type, messaging.destination.name).
+    metrics-attributes-deny: ""
 
     # sink-event-error-reporting.enable whether the adapter reports a kube event to the CRD indicating
     # a failure to send a cloud event to the sink.

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -13,6 +13,7 @@ echo "Release: $release"
 
 "${root_dir}"/hack/update-codegen.sh
 git apply "${root_dir}"/openshift/patches/027-rekt-serviceaccounts-delete.patch
+git apply "${root_dir}"/openshift/patches/028-metrics-attributes-deny.patch
 
 ./openshift/generate.sh
 

--- a/pkg/observability/config_test.go
+++ b/pkg/observability/config_test.go
@@ -23,8 +23,11 @@ import (
 )
 
 func TestNewFromMap(t *testing.T) {
-	configWithOverride := DefaultConfig()
-	configWithOverride.EnableSinkEventErrorReporting = true
+	configWithSinkEventErrorReporting := DefaultConfig()
+	configWithSinkEventErrorReporting.EnableSinkEventErrorReporting = true
+
+	configWithDenyList := DefaultConfig()
+	configWithDenyList.Metrics.AttributesDeny = "cloudevents.type, messaging.destination.name"
 
 	testCases := map[string]struct {
 		m                map[string]string
@@ -39,7 +42,13 @@ func TestNewFromMap(t *testing.T) {
 			m: map[string]string{
 				EnableSinkEventErrorReportingKey: "true",
 			},
-			want: configWithOverride,
+			want: configWithSinkEventErrorReporting,
+		},
+		"metric attributes deny list": {
+			m: map[string]string{
+				"metrics-attributes-deny": "cloudevents.type, messaging.destination.name",
+			},
+			want: configWithDenyList,
 		},
 		"valid keys, invalid sink event error reporting value": {
 			m: map[string]string{

--- a/pkg/observability/otel/otel.go
+++ b/pkg/observability/otel/otel.go
@@ -60,10 +60,15 @@ func SetupObservabilityOrDie(
 
 	otelResource := resource.Default(component)
 
+	meterOpts := []metric.Option{metric.WithResource(otelResource)}
+	if denyList := cfg.Metrics.AttributesDenyList(); len(denyList) > 0 {
+		meterOpts = append(meterOpts, metric.WithView(metrics.MetricAttributesDenyFilter(denyList)))
+	}
+
 	meterProvider, err := metrics.NewMeterProvider(
 		ctx,
 		cfg.Metrics,
-		metric.WithResource(otelResource),
+		meterOpts...,
 	)
 	if err != nil {
 		logger.Fatalw("failed to set up meter provider", zap.Error(err))

--- a/pkg/observability/otel/otel_test.go
+++ b/pkg/observability/otel/otel_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package otel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric"
+
+	"knative.dev/pkg/observability/metrics"
+)
+
+func TestMetricAttributesDenyFilter(t *testing.T) {
+	view := metrics.MetricAttributesDenyFilter([]string{"cloudevents.type", "messaging.destination.name"})
+
+	stream, ok := view(metric.Instrument{Name: "kn.eventing.dispatch.duration"})
+	assert.True(t, ok, "view should match all instruments")
+	assert.NotNil(t, stream.AttributeFilter)
+
+	denied := []attribute.KeyValue{
+		attribute.String("cloudevents.type", "com.example.event"),
+		attribute.String("messaging.destination.name", "my-destination"),
+	}
+	for _, kv := range denied {
+		assert.False(t, stream.AttributeFilter(kv), "attribute %s should be denied", kv.Key)
+	}
+
+	allowed := []attribute.KeyValue{
+		attribute.String("messaging.system", "knative"),
+		attribute.Int("http.response.status_code", 200),
+	}
+	for _, kv := range allowed {
+		assert.True(t, stream.AttributeFilter(kv), "attribute %s should be allowed", kv.Key)
+	}
+}
+
+func TestMetricAttributesDenyFilterMatchesAllInstruments(t *testing.T) {
+	view := metrics.MetricAttributesDenyFilter([]string{"cloudevents.type"})
+
+	stream, ok := view(metric.Instrument{Name: "http.server.request.duration"})
+	assert.True(t, ok, "view should match all instruments")
+	assert.NotNil(t, stream.AttributeFilter)
+}

--- a/vendor/knative.dev/pkg/injection/sharedmain/main.go
+++ b/vendor/knative.dev/pkg/injection/sharedmain/main.go
@@ -399,10 +399,15 @@ func SetupObservabilityOrDie(
 
 	resource := resource.Default(component)
 
+	views := OTelViews(ctx)
+	if denyList := cfg.Metrics.AttributesDenyList(); len(denyList) > 0 {
+		views = append(views, metrics.MetricAttributesDenyFilter(denyList))
+	}
+
 	meterProvider, err := metrics.NewMeterProvider(
 		ctx,
 		cfg.Metrics,
-		metric.WithView(OTelViews(ctx)...),
+		metric.WithView(views...),
 		metric.WithResource(resource),
 	)
 	if err != nil {

--- a/vendor/knative.dev/pkg/observability/metrics/config.go
+++ b/vendor/knative.dev/pkg/observability/metrics/config.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	configmap "knative.dev/pkg/configmap/parser"
@@ -38,6 +39,28 @@ type Config struct {
 	Protocol       string        `json:"protocol,omitempty"`
 	Endpoint       string        `json:"endpoint,omitempty"`
 	ExportInterval time.Duration `json:"exportInterval,omitempty"`
+
+	// AttributesDeny is a comma-separated list of metric attribute keys to
+	// filter out from all instruments (e.g. "cloudevents.type,messaging.destination.name").
+	// Stored as a string rather than []string to keep Config comparable,
+	// which is relied upon by downstream consumers. Use AttributesDenyList()
+	// to get the parsed list.
+	AttributesDeny string `json:"attributesDeny,omitempty"`
+}
+
+// AttributesDenyList returns the deny list parsed into individual keys.
+func (c *Config) AttributesDenyList() []string {
+	if c.AttributesDeny == "" {
+		return nil
+	}
+	parts := strings.Split(c.AttributesDeny, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			result = append(result, t)
+		}
+	}
+	return result
 }
 
 func (c *Config) Validate() error {
@@ -79,6 +102,7 @@ func NewFromMapWithPrefix(prefix string, m map[string]string) (Config, error) {
 	c := DefaultConfig()
 
 	err := configmap.Parse(m,
+		configmap.As(prefix+"metrics-attributes-deny", &c.AttributesDeny),
 		configmap.As(prefix+"metrics-protocol", &c.Protocol),
 		configmap.As(prefix+"metrics-endpoint", &c.Endpoint),
 		configmap.As(prefix+"metrics-export-interval", &c.ExportInterval),

--- a/vendor/knative.dev/pkg/observability/metrics/view.go
+++ b/vendor/knative.dev/pkg/observability/metrics/view.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric"
+)
+
+// MetricAttributesDenyFilter returns a View that strips the given attribute
+// keys from every instrument.
+func MetricAttributesDenyFilter(denyList []string) metric.View {
+	keys := make([]attribute.Key, len(denyList))
+	for i, k := range denyList {
+		keys[i] = attribute.Key(k)
+	}
+	return metric.NewView(
+		metric.Instrument{Name: "*"},
+		metric.Stream{
+			AttributeFilter: attribute.NewDenyKeysFilter(keys...),
+		},
+	)
+}


### PR DESCRIPTION
Vendor knative.dev/pkg changes that add a metrics-attributes-deny config key for filtering high-cardinality metric attributes from all instruments via an OTel View. Add documentation for the new key in config-observability.