### PR TITLE
[release-v1.21] backports Wait in adapter for goroutines before returning in startFailFast

### DIFF
--- a/pkg/adapter/apiserver/adapter.go
+++ b/pkg/adapter/apiserver/adapter.go
@@ -182,11 +182,14 @@ func (a *apiServerAdapter) startFailFast(ctx context.Context, stopCh <-chan stru
 	select {
 	case err := <-errorChan:
 		if err != nil {
+			cancelWatchers()
+			wg.Wait()
 			a.logger.Errorf("ApiServerSource failed: %v", err)
 			return err
 		}
 	case <-stopCh:
 		cancelWatchers()
+		wg.Wait()
 		return nil
 	}
 


### PR DESCRIPTION
backports https://github.com/knative/eventing/pull/9030/